### PR TITLE
Add presentation routes and pages

### DIFF
--- a/app/routes/faculty.py
+++ b/app/routes/faculty.py
@@ -132,6 +132,51 @@ async def profile_page(
         }
     )
 
+@router.get("/presentations", response_class=HTMLResponse)
+async def presentations_page(
+    request: Request,
+    current_faculty: FacultyProfile = Depends(get_current_faculty)
+):
+    """View faculty presentations"""
+    return templates.TemplateResponse(
+        "faculty/presentations.html",
+        {
+            "request": request,
+            "faculty": current_faculty,
+            "active_page": "faculty_presentations",
+        },
+    )
+
+@router.get("/journey", response_class=HTMLResponse)
+async def journey_page(
+    request: Request,
+    current_faculty: FacultyProfile = Depends(get_current_faculty)
+):
+    """View faculty journey details"""
+    return templates.TemplateResponse(
+        "faculty/journey.html",
+        {
+            "request": request,
+            "faculty": current_faculty,
+            "active_page": "faculty_journey",
+        },
+    )
+
+@router.get("/messages", response_class=HTMLResponse)
+async def messages_page(
+    request: Request,
+    current_faculty: FacultyProfile = Depends(get_current_faculty)
+):
+    """Placeholder page for faculty messages"""
+    return templates.TemplateResponse(
+        "faculty/messages.html",
+        {
+            "request": request,
+            "faculty": current_faculty,
+            "active_page": "faculty_messages",
+        },
+    )
+
 @router.post("/profile/update")
 async def update_profile(
     request: Request,

--- a/templates/faculty/journey.html
+++ b/templates/faculty/journey.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}Journey Details | Conference Management{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <h1 class="h3 mb-4">Journey Details</h1>
+    <a href="/faculty/profile" class="btn btn-outline-secondary btn-sm mb-3">
+        <i class="fas fa-arrow-left me-1"></i> Back to Profile
+    </a>
+    <div class="card shadow-sm border-0">
+        <div class="card-body">
+            {% if faculty.journey_details %}
+            <dl class="row mb-0">
+                <dt class="col-sm-3">Arrival Date</dt>
+                <dd class="col-sm-9">{{ faculty.journey_details.arrival_date }}</dd>
+                <dt class="col-sm-3">Departure Date</dt>
+                <dd class="col-sm-9">{{ faculty.journey_details.departure_date }}</dd>
+                <dt class="col-sm-3">Origin City</dt>
+                <dd class="col-sm-9">{{ faculty.journey_details.origin_city }}</dd>
+                <dt class="col-sm-3">Destination City</dt>
+                <dd class="col-sm-9">{{ faculty.journey_details.destination_city }}</dd>
+                {% if faculty.journey_details.remarks %}
+                <dt class="col-sm-3">Remarks</dt>
+                <dd class="col-sm-9">{{ faculty.journey_details.remarks }}</dd>
+                {% endif %}
+            </dl>
+            {% else %}
+            <p class="mb-0">No journey information available.</p>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/faculty/messages.html
+++ b/templates/faculty/messages.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block title %}Faculty Messages | Conference Management{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <h1 class="h3 mb-4">Messages</h1>
+    <a href="/faculty/profile" class="btn btn-outline-secondary btn-sm mb-3">
+        <i class="fas fa-arrow-left me-1"></i> Back to Profile
+    </a>
+    <p>This feature is coming soon.</p>
+</div>
+{% endblock %}

--- a/templates/faculty/presentations.html
+++ b/templates/faculty/presentations.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block title %}Faculty Presentations | Conference Management{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <h1 class="h3 mb-4">My Presentations</h1>
+    <a href="/faculty/profile" class="btn btn-outline-secondary btn-sm mb-3">
+        <i class="fas fa-arrow-left me-1"></i> Back to Profile
+    </a>
+    <div class="card shadow-sm border-0">
+        <div class="card-header bg-white">
+            <h5 class="mb-0">Presentations</h5>
+        </div>
+        <div class="card-body">
+            {% if faculty.presentations %}
+            <ul class="list-group">
+                {% for presentation in faculty.presentations %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <div>
+                        <strong>{{ presentation.title }}</strong>
+                        <div class="small text-muted">{{ presentation.description }}</div>
+                    </div>
+                    <a href="/static/{{ presentation.file_path }}" class="btn btn-sm btn-outline-primary" target="_blank">
+                        <i class="fas fa-download me-1"></i> Download
+                    </a>
+                </li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p class="mb-0">No presentations uploaded yet.</p>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/guest/presentations.html
+++ b/templates/guest/presentations.html
@@ -1,0 +1,124 @@
+{% extends "base.html" %}
+
+{% block title %}My Presentations | Conference Management{% endblock %}
+
+{% block content %}
+<div class="row mb-4">
+    <div class="col-12">
+        <h1 class="h3 mb-2">My Presentations</h1>
+        <a href="/guest/profile" class="btn btn-outline-secondary btn-sm">
+            <i class="fas fa-arrow-left me-1"></i> Back to Profile
+        </a>
+    </div>
+</div>
+
+<div class="card shadow-sm border-0">
+    <div class="card-header bg-white d-flex justify-content-between align-items-center">
+        <h5 class="mb-0">Your Presentations</h5>
+        <button type="button" class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#uploadPresentationModal">
+            <i class="fas fa-upload me-1"></i> Upload New
+        </button>
+    </div>
+    <div class="card-body">
+        {% if presentations %}
+        <div class="row">
+            {% for presentation in presentations %}
+            <div class="col-md-6 mb-3">
+                <div class="card h-100 border-0 shadow-sm">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between">
+                            <h6 class="card-title">{{ presentation.title }}</h6>
+                            <span class="badge {% if presentation.file_type == 'pdf' %}bg-danger{% elif presentation.file_type == 'ppt' %}bg-warning{% elif presentation.file_type == 'video' %}bg-primary{% else %}bg-success{% endif %}">{{ presentation.file_type|upper }}</span>
+                        </div>
+                        <p class="card-text small text-muted">{{ presentation.description|truncate(100) }}</p>
+                        <p class="card-text small">
+                            <i class="fas fa-calendar-alt me-1"></i> {{ presentation.upload_date }}
+                        </p>
+                    </div>
+                    <div class="card-footer bg-white">
+                        <a href="{{ presentation.file_url }}" class="btn btn-sm btn-outline-primary" target="_blank">
+                            <i class="fas fa-download me-1"></i> Download
+                        </a>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+        {% else %}
+        <div class="text-center py-5">
+            <i class="fas fa-file-upload fa-3x text-muted mb-3"></i>
+            <h5>No Presentations Yet</h5>
+            <p class="text-muted">Upload your presentations for the conference here.</p>
+            <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#uploadPresentationModal">
+                <i class="fas fa-upload me-2"></i> Upload Your First Presentation
+            </button>
+        </div>
+        {% endif %}
+    </div>
+</div>
+
+<!-- Upload Presentation Modal -->
+<div class="modal fade" id="uploadPresentationModal" tabindex="-1" aria-labelledby="uploadPresentationModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="uploadPresentationModalLabel">Upload Presentation</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form id="uploadPresentationForm" method="post" action="/guest/upload-presentation" enctype="multipart/form-data">
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="title" class="form-label">Presentation Title</label>
+                        <input type="text" class="form-control" id="title" name="title" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="description" class="form-label">Description</label>
+                        <textarea class="form-control" id="description" name="description" rows="3"></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label for="file" class="form-label">Presentation File</label>
+                        <input type="file" class="form-control" id="file" name="file" required accept=".pdf,.ppt,.pptx,.doc,.docx,.mp4,.avi,.webm">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Upload Presentation</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const form = document.getElementById('uploadPresentationForm');
+        if (form) {
+            form.addEventListener('submit', function(e) {
+                e.preventDefault();
+                const formData = new FormData(this);
+                fetch(this.action, { method: 'POST', body: formData })
+                    .then(r => r.json())
+                    .then(data => {
+                        if (data.success) {
+                            const modalElement = this.closest('.modal');
+                            if (modalElement) {
+                                const modal = bootstrap.Modal.getInstance(modalElement);
+                                modal.hide();
+                            }
+                            alert(data.message || 'Presentation uploaded successfully');
+                            location.reload();
+                        } else {
+                            alert(data.message || 'An error occurred');
+                        }
+                    })
+                    .catch(err => {
+                        console.error('Error:', err);
+                        alert('An unexpected error occurred');
+                    });
+            });
+        }
+    });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a presentations page for guests
- create placeholder faculty pages for presentations, journey, and messages
- define missing routes in guest and faculty blueprints

## Testing
- `python -m py_compile app/routes/guest.py app/routes/faculty.py`

------
https://chatgpt.com/codex/tasks/task_e_68402cb61814832ca194947df3001127