### PR TITLE
Add presentation and messaging management features

### DIFF
--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -208,7 +208,21 @@
                             <span>Gift Management</span>
                         </a>
                     </div>
-                    
+
+                    <div class="col-md-4 mb-3">
+                        <a href="/admin/presentations_management" class="btn btn-info w-100 h-100 d-flex flex-column align-items-center justify-content-center py-4">
+                            <i class="fas fa-file-powerpoint fa-2x mb-2"></i>
+                            <span>Presentation Management</span>
+                        </a>
+                    </div>
+
+                    <div class="col-md-4 mb-3">
+                        <a href="/admin/messages" class="btn btn-dark w-100 h-100 d-flex flex-column align-items-center justify-content-center py-4">
+                            <i class="fas fa-envelope fa-2x mb-2"></i>
+                            <span>Message Center</span>
+                        </a>
+                    </div>
+
                     <div class="col-md-4 mb-3">
                         <a href="/admin/report" class="btn btn-secondary w-100 h-100 d-flex flex-column align-items-center justify-content-center py-4">
                             <i class="fas fa-chart-bar fa-2x mb-2"></i>

--- a/templates/admin/messages_management.html
+++ b/templates/admin/messages_management.html
@@ -22,6 +22,7 @@
                         <th>Phone</th>
                         <th>Role</th>
                         <th>Message</th>
+                        <th>Response</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -33,9 +34,21 @@
                         <td>{{ msg.phone }}</td>
                         <td>{{ msg.role }}</td>
                         <td>{{ msg.message }}</td>
+                        <td>
+                            {% if msg.response %}
+                                <div>{{ msg.response }}</div>
+                                <div class="small text-muted">{{ msg.response_timestamp }}</div>
+                            {% else %}
+                                <form method="post" action="/admin/respond_message" class="d-flex">
+                                    <input type="hidden" name="message_id" value="{{ msg.id }}">
+                                    <input type="text" name="response" class="form-control form-control-sm me-2" placeholder="Response">
+                                    <button class="btn btn-sm btn-primary" type="submit">Send</button>
+                                </form>
+                            {% endif %}
+                        </td>
                     </tr>
                 {% else %}
-                    <tr><td colspan="6" class="text-center">No messages found.</td></tr>
+                    <tr><td colspan="7" class="text-center">No messages found.</td></tr>
                 {% endfor %}
                 </tbody>
             </table>

--- a/templates/admin/presentations_management.html
+++ b/templates/admin/presentations_management.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% block title %}Presentations Management | Conference Management{% endblock %}
+
+{% block content %}
+<div class="row mb-4">
+    <div class="col-12">
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="h3 mb-1">Presentations Management</h1>
+                <p class="text-muted mb-0">Review and download uploaded presentations</p>
+            </div>
+            <a href="/admin/dashboard" class="btn btn-outline-secondary">
+                <i class="fas fa-arrow-left me-1"></i> Back to Dashboard
+            </a>
+        </div>
+        <div class="table-responsive mt-4">
+            <table class="table table-bordered table-hover">
+                <thead class="table-light">
+                    <tr>
+                        <th>Guest</th>
+                        <th>Role</th>
+                        <th>Title</th>
+                        <th>Uploaded</th>
+                        <th>File</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for p in presentations %}
+                    <tr>
+                        <td>{{ p.guest_name }} ({{ p.guest_id }})</td>
+                        <td>{{ p.guest_role }}</td>
+                        <td>{{ p.title }}</td>
+                        <td>{{ p.upload_date }}</td>
+                        <td><a href="{{ p.file_url }}" class="btn btn-sm btn-primary"><i class="fas fa-download me-1"></i>Download</a></td>
+                    </tr>
+                {% else %}
+                    <tr><td colspan="5" class="text-center">No presentations found.</td></tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/single_guest.html
+++ b/templates/admin/single_guest.html
@@ -396,6 +396,16 @@
                         </button>
                     </li>
                     <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="presentations-tab" data-bs-toggle="tab" data-bs-target="#presentations" type="button" role="tab">
+                            <i class="fas fa-file-powerpoint me-2"></i>Presentations
+                        </button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="messages-tab" data-bs-toggle="tab" data-bs-target="#messages" type="button" role="tab">
+                            <i class="fas fa-envelope me-2"></i>Messages
+                        </button>
+                    </li>
+                    <li class="nav-item" role="presentation">
                         <button class="nav-link" id="status-tab" data-bs-toggle="tab" data-bs-target="#status" type="button" role="tab">
                             <i class="fas fa-chart-line me-2"></i>Status
                         </button>
@@ -1025,6 +1035,60 @@
                                     </div>
                                 </div>
                             </div>
+                        </div>
+                    </div>
+
+                    <!-- Presentations Tab -->
+                    <div class="tab-pane fade" id="presentations" role="tabpanel" aria-labelledby="presentations-tab">
+                        <h5 class="mb-3">Uploaded Presentations</h5>
+                        <div class="table-responsive">
+                            <table class="table table-bordered">
+                                <thead class="table-light">
+                                <tr>
+                                    <th>Title</th>
+                                    <th>Uploaded</th>
+                                    <th>File</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {% for p in presentations %}
+                                <tr>
+                                    <td>{{ p.title }}</td>
+                                    <td>{{ p.upload_date }}</td>
+                                    <td><a href="{{ p.file_url }}" class="btn btn-sm btn-primary"><i class="fas fa-download me-1"></i>Download</a></td>
+                                </tr>
+                                {% else %}
+                                <tr><td colspan="3" class="text-center">No presentations found.</td></tr>
+                                {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <!-- Messages Tab -->
+                    <div class="tab-pane fade" id="messages" role="tabpanel" aria-labelledby="messages-tab">
+                        <h5 class="mb-3">Messages</h5>
+                        <div class="table-responsive">
+                            <table class="table table-bordered">
+                                <thead class="table-light">
+                                <tr>
+                                    <th>Timestamp</th>
+                                    <th>Message</th>
+                                    <th>Response</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {% for m in messages %}
+                                <tr>
+                                    <td>{{ m.timestamp }}</td>
+                                    <td>{{ m.message }}</td>
+                                    <td>{{ m.response or '-' }}</td>
+                                </tr>
+                                {% else %}
+                                <tr><td colspan="3" class="text-center">No messages found.</td></tr>
+                                {% endfor %}
+                                </tbody>
+                            </table>
                         </div>
                     </div>
 

--- a/templates/guest/profile.html
+++ b/templates/guest/profile.html
@@ -316,10 +316,24 @@
                         
                         <h6 class="mb-3">Message History</h6>
                         <div id="messageHistory">
-                            <!-- Message history will be displayed here -->
+                            {% if messages %}
+                                {% for msg in messages %}
+                                <div class="mb-3 border rounded p-2">
+                                    <div class="small text-muted">{{ msg.timestamp }}</div>
+                                    <p class="mb-1">{{ msg.message }}</p>
+                                    {% if msg.response %}
+                                    <div class="bg-light p-2 mt-2 rounded">
+                                        <strong>Admin:</strong> {{ msg.response }}
+                                        <div class="small text-muted">{{ msg.response_timestamp }}</div>
+                                    </div>
+                                    {% endif %}
+                                </div>
+                                {% endfor %}
+                            {% else %}
                             <div class="text-center py-4">
                                 <p class="text-muted">No messages yet</p>
                             </div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- allow guests to send messages with optional admin response
- display messages on guest profile page
- add presentation management page and message center for admins
- support responding to guest messages
- show presentations and messages in single guest view
- link new pages from dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68403695fc70832cad0f51365431aefd