### PR TITLE
Improve admin dashboard navigation and conference settings

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from app.routes import admin, guest, common
 from app.services.csv_db import CSVDatabase
 # Replace the current templates initialization in main.py
 from app.templates import templates
+from app.utils.conference_settings import load_settings
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 from app.services.qr_service import QRService
 from fastapi import Path
@@ -96,6 +97,7 @@ from datetime import datetime
 # Initialize templates with global variables
 templates = Jinja2Templates(directory=config.get('PATHS', 'TemplatesDir'))
 templates.env.globals["now"] = datetime.now()
+templates.env.globals["conference"] = load_settings()
 
 # Include routers
 # Include routers

--- a/app/utils/conference_settings.py
+++ b/app/utils/conference_settings.py
@@ -1,0 +1,23 @@
+import os
+import json
+
+SETTINGS_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', 'conference_settings.json')
+
+
+def load_settings():
+    if not os.path.exists(SETTINGS_FILE):
+        return {
+            "name": "Sample Conference",
+            "address": "Conference Venue",
+            "date": "2025-01-01",
+            "header_image": "/static/images/header.jpeg",
+            "agenda_csv": ""
+        }
+    with open(SETTINGS_FILE, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def save_settings(settings: dict):
+    os.makedirs(os.path.dirname(SETTINGS_FILE), exist_ok=True)
+    with open(SETTINGS_FILE, 'w', encoding='utf-8') as f:
+        json.dump(settings, f, indent=4)

--- a/data/conference_settings.json
+++ b/data/conference_settings.json
@@ -1,0 +1,7 @@
+{
+    "name": "Sample Conference",
+    "address": "Conference Venue",
+    "date": "2025-01-01",
+    "header_image": "/static/images/header.jpeg",
+    "agenda_csv": ""
+}

--- a/templates/admin/backup.html
+++ b/templates/admin/backup.html
@@ -5,8 +5,15 @@
 {% block content %}
 <div class="row mb-4">
     <div class="col-12">
-        <h1 class="h3 mb-2">Database Backups</h1>
-        <p class="text-muted">Manage database backups and restoration</p>
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="h3 mb-2">Database Backups</h1>
+                <p class="text-muted">Manage database backups and restoration</p>
+            </div>
+            <a href="/admin/dashboard" class="btn btn-outline-secondary">
+                <i class="fas fa-arrow-left me-1"></i> Back to Dashboard
+            </a>
+        </div>
     </div>
 </div>
 

--- a/templates/admin/conference_settings.html
+++ b/templates/admin/conference_settings.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}Conference Settings{% endblock %}
+{% block content %}
+<div class="row mb-4">
+    <div class="col-12 d-flex justify-content-between align-items-center">
+        <h1 class="h3 mb-0">Conference Settings</h1>
+        <a href="/admin/dashboard" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-left me-1"></i> Back to Dashboard
+        </a>
+    </div>
+</div>
+<form method="post" enctype="multipart/form-data" class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">Conference Name</label>
+        <input type="text" class="form-control" name="name" value="{{ settings.name }}" required>
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Conference Date</label>
+        <input type="text" class="form-control" name="date" value="{{ settings.date }}" required>
+    </div>
+    <div class="col-md-12">
+        <label class="form-label">Conference Address</label>
+        <input type="text" class="form-control" name="address" value="{{ settings.address }}" required>
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Header Image</label>
+        <input type="file" class="form-control" name="header_image">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Agenda CSV</label>
+        <input type="file" class="form-control" name="agenda">
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Save Settings</button>
+    </div>
+</form>
+{% endblock %}

--- a/templates/admin/messages_management.html
+++ b/templates/admin/messages_management.html
@@ -4,8 +4,15 @@
 {% block content %}
 <div class="row mb-4">
     <div class="col-12">
-        <h1 class="h3 mb-1">Messages Management</h1>
-        <p class="text-muted mb-0">Review all messages submitted by guests</p>
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="h3 mb-1">Messages Management</h1>
+                <p class="text-muted mb-0">Review all messages submitted by guests</p>
+            </div>
+            <a href="/admin/dashboard" class="btn btn-outline-secondary">
+                <i class="fas fa-arrow-left me-1"></i> Back to Dashboard
+            </a>
+        </div>
         <form method="get" class="my-3">
             <div class="input-group">
                 <input type="text" class="form-control" name="q" value="{{ search_query or '' }}" placeholder="Search by guest name, phone or message...">

--- a/templates/admin/report.html
+++ b/templates/admin/report.html
@@ -6,8 +6,15 @@
 {% block content %}
 <div class="row mb-4">
     <div class="col-12">
-        <h1 class="h3 mb-2">Conference Reports</h1>
-        <p class="text-muted">Generate and view comprehensive reports for the conference</p>
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="h3 mb-2">Conference Reports</h1>
+                <p class="text-muted">Generate and view comprehensive reports for the conference</p>
+            </div>
+            <a href="/admin/dashboard" class="btn btn-outline-secondary">
+                <i class="fas fa-arrow-left me-1"></i> Back to Dashboard
+            </a>
+        </div>
     </div>
 </div>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,7 @@
 </head>
 <body class="d-flex flex-column min-vh-100">
     <!-- Header -->
-    <header class="header-banner">
+    <header class="header-banner" style="background-image: url('{{ conference.header_image }}');">
         {% include 'components/header.html' %}
     </header>
 

--- a/templates/check_in.html
+++ b/templates/check_in.html
@@ -13,6 +13,9 @@
                 <div class="alert alert-info">
                     <i class="fas fa-info-circle me-2"></i> Scan a guest's QR code or enter their ID to check them in
                 </div>
+                {% if error %}
+                <div class="alert alert-danger mt-2">{{ error }}</div>
+                {% endif %}
                 
                 <div class="mb-4">
                     <form id="checkInForm" method="post" action="/check_in_guest" class="needs-validation" novalidate>
@@ -198,8 +201,8 @@
                 {% endif %}
                 
                 <div class="text-center mt-4">
-                    <a href="/" class="btn btn-outline-secondary">
-                        <i class="fas fa-arrow-left me-2"></i> Back to Home
+                    <a href="/admin/dashboard" class="btn btn-outline-secondary">
+                        <i class="fas fa-arrow-left me-2"></i> Back to Dashboard
                     </a>
                 </div>
             </div>

--- a/templates/components/footer.html
+++ b/templates/components/footer.html
@@ -3,10 +3,9 @@
     <div class="row">
         <div class="col-md-4">
             <h5><i class="fas fa-university me-2"></i> Event Details</h5>
-            <p class="mb-0">10th Bengal</p>
-            <p class="mb-0">Diabites</p>
-            <p class="mb-0">Conference</p>
-            <p class="mb-0">Durgapur</p>
+            <p class="mb-0">{{ conference.name }}</p>
+            <p class="mb-0">{{ conference.address }}</p>
+            <p class="mb-0">{{ conference.date }}</p>
         </div>
         <div class="col-md-4 text-center">
             <h5><i class="fas fa-envelope me-2"></i> Contact Info</h5>

--- a/templates/components/header.html
+++ b/templates/components/header.html
@@ -2,7 +2,8 @@
 <div class="header-content text-center text-white">
     <div class="position-relative h-100 d-flex align-items-center justify-content-center">
         <div class="header-text p-4" style="z-index: 2;">
-
+            <h1 class="display-6">{{ conference.name }}</h1>
+            <p class="mb-0">{{ conference.date }} - {{ conference.address }}</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add back-to-dashboard buttons on several admin pages
- fix check-in page with guest lookup and attendance marking
- implement secret admin URL to edit conference settings
- render dynamic conference details in header and footer

## Testing
- `python3 -m py_compile app/main.py app/routes/admin.py app/routes/common.py app/utils/conference_settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68404324ee84832c997b0b96182a1961