### PR TITLE
Handle missing conference settings on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ wheels/
 
 # Data files
 data/
+!data/conference_settings.json
 *.csv
 *.db
 *.sqlite

--- a/app/templates.py
+++ b/app/templates.py
@@ -2,20 +2,20 @@ from fastapi.templating import Jinja2Templates
 from datetime import datetime
 import os
 
+from app.utils.conference_settings import load_settings
+
 # Initialize templates with a default path, will be updated in main.py
 templates = Jinja2Templates(directory="templates")
 
 # Add global variables
 templates.env.globals["now"] = datetime.now()
+templates.env.globals["conference"] = load_settings()
 
 def update_template_directory(directory_path):
     """Update template directory after config is loaded"""
     global templates
-    if os.path.exists(directory_path):
-        templates = Jinja2Templates(directory=directory_path)
-        templates.env.globals["now"] = datetime.now()
-    else:
-        # Create the directory if it doesn't exist
+    if not os.path.exists(directory_path):
         os.makedirs(directory_path, exist_ok=True)
-        templates = Jinja2Templates(directory=directory_path)
-        templates.env.globals["now"] = datetime.now()
+    templates = Jinja2Templates(directory=directory_path)
+    templates.env.globals["now"] = datetime.now()
+    templates.env.globals["conference"] = load_settings()

--- a/app/utils/conference_settings.py
+++ b/app/utils/conference_settings.py
@@ -5,14 +5,20 @@ SETTINGS_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data',
 
 
 def load_settings():
+    defaults = {
+        "name": "Sample Conference",
+        "address": "Conference Venue",
+        "date": "2025-01-01",
+        "header_image": "/static/images/header.jpeg",
+        "agenda_csv": ""
+    }
+
     if not os.path.exists(SETTINGS_FILE):
-        return {
-            "name": "Sample Conference",
-            "address": "Conference Venue",
-            "date": "2025-01-01",
-            "header_image": "/static/images/header.jpeg",
-            "agenda_csv": ""
-        }
+        os.makedirs(os.path.dirname(SETTINGS_FILE), exist_ok=True)
+        with open(SETTINGS_FILE, 'w', encoding='utf-8') as f:
+            json.dump(defaults, f, indent=4)
+        return defaults
+
     with open(SETTINGS_FILE, 'r', encoding='utf-8') as f:
         return json.load(f)
 


### PR DESCRIPTION
## Summary
- create `data/conference_settings.json` automatically when missing
- expose `conference` settings through the `templates` module
- keep `data/conference_settings.json` under version control

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684049c4b188832cb0d17a1da8cdf2e0