### PR TITLE
Display parsed agenda from CSV

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -97,7 +97,10 @@ from datetime import datetime
 # Initialize templates with global variables
 templates = Jinja2Templates(directory=config.get('PATHS', 'TemplatesDir'))
 templates.env.globals["now"] = datetime.now()
-templates.env.globals["conference"] = load_settings()
+settings = load_settings()
+templates.env.globals["conference"] = settings
+from app.utils.conference_settings import parse_agenda_csv
+templates.env.globals["agenda"] = parse_agenda_csv(settings.get("agenda_csv", ""))
 
 # Include routers
 # Include routers

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -3046,7 +3046,7 @@ ensure_enhanced_gift_fields()
 
 # -----------------------------------------
 # Conference settings management
-from app.utils.conference_settings import load_settings, save_settings
+from app.utils.conference_settings import load_settings, save_settings, parse_agenda_csv
 from fastapi import UploadFile, File
 from pathlib import Path
 
@@ -3092,4 +3092,5 @@ async def update_conference_settings(
 
     save_settings(settings)
     templates.env.globals["conference"] = settings
+    templates.env.globals["agenda"] = parse_agenda_csv(settings.get("agenda_csv", ""))
     return RedirectResponse(url=CONFERENCE_SETTINGS_PATH, status_code=303)

--- a/app/utils/conference_settings.py
+++ b/app/utils/conference_settings.py
@@ -1,5 +1,7 @@
 import os
 import json
+import csv
+from typing import List, Dict
 
 SETTINGS_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', 'conference_settings.json')
 
@@ -21,3 +23,37 @@ def save_settings(settings: dict):
     os.makedirs(os.path.dirname(SETTINGS_FILE), exist_ok=True)
     with open(SETTINGS_FILE, 'w', encoding='utf-8') as f:
         json.dump(settings, f, indent=4)
+
+
+def parse_agenda_csv(agenda_path: str) -> List[Dict[str, str]]:
+    """Parse agenda CSV into structured data.
+
+    The CSV file is expected to contain the columns ``Date``, ``Time``,
+    ``Event`` and ``Location`` (case insensitive).  If the file or path is
+    missing, an empty list is returned.
+    """
+    if not agenda_path:
+        return []
+
+    # Support relative paths stored in settings
+    if not os.path.isabs(agenda_path):
+        agenda_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), agenda_path)
+
+    if not os.path.exists(agenda_path):
+        return []
+
+    agenda = []
+    try:
+        with open(agenda_path, newline='', encoding='utf-8-sig') as csvfile:
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                agenda.append({
+                    "date": row.get("Date") or row.get("date", ""),
+                    "time": row.get("Time") or row.get("time", ""),
+                    "event": row.get("Event") or row.get("event", ""),
+                    "location": row.get("Location") or row.get("location", ""),
+                })
+    except Exception:
+        return []
+
+    return agenda

--- a/templates/guest/presentations.html
+++ b/templates/guest/presentations.html
@@ -54,6 +54,40 @@
             </button>
         </div>
         {% endif %}
+</div>
+</div>
+
+<div class="card shadow-sm border-0 mt-4">
+    <div class="card-header bg-white">
+        <h5 class="mb-0">Conference Agenda</h5>
+    </div>
+    <div class="card-body">
+        <div class="table-responsive">
+            {% if agenda %}
+            <table class="table table-hover">
+                <thead class="table-light">
+                    <tr>
+                        <th>Date</th>
+                        <th>Time</th>
+                        <th>Event</th>
+                        <th>Location</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for item in agenda %}
+                    <tr>
+                        <td>{{ item.date }}</td>
+                        <td>{{ item.time }}</td>
+                        <td>{{ item.event }}</td>
+                        <td>{{ item.location }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <p class="text-muted mb-0">Agenda will be available soon.</p>
+            {% endif %}
+        </div>
     </div>
 </div>
 

--- a/templates/guest/profile.html
+++ b/templates/guest/profile.html
@@ -123,6 +123,7 @@
                             <div class="col-12">
                                 <h6 class="fw-bold">Conference Schedule</h6>
                                 <div class="table-responsive">
+                                    {% if agenda %}
                                     <table class="table table-hover">
                                         <thead class="table-light">
                                             <tr>
@@ -133,26 +134,19 @@
                                             </tr>
                                         </thead>
                                         <tbody>
+                                            {% for item in agenda %}
                                             <tr>
-                                                <td>May 20, 2025</td>
-                                                <td>09:00 - 10:30</td>
-                                                <td>Registration & Welcome Kit</td>
-                                                <td>Main Lobby</td>
+                                                <td>{{ item.date }}</td>
+                                                <td>{{ item.time }}</td>
+                                                <td>{{ item.event }}</td>
+                                                <td>{{ item.location }}</td>
                                             </tr>
-                                            <tr>
-                                                <td>May 20, 2025</td>
-                                                <td>11:00 - 12:30</td>
-                                                <td>Inaugural Ceremony</td>
-                                                <td>Auditorium</td>
-                                            </tr>
-                                            <tr>
-                                                <td>May 21, 2025</td>
-                                                <td>09:30 - 11:30</td>
-                                                <td>Faculty Presentations</td>
-                                                <td>Conference Rooms</td>
-                                            </tr>
+                                            {% endfor %}
                                         </tbody>
                                     </table>
+                                    {% else %}
+                                    <p class="text-muted">Agenda will be available soon.</p>
+                                    {% endif %}
                                 </div>
                                 <div class="text-end">
                                     <a href="#" class="btn btn-sm btn-outline-primary">


### PR DESCRIPTION
## Summary
- parse agenda CSV in conference settings
- load agenda in template globals
- keep agenda updated when admin saves settings
- show agenda table in guest profile and presentations pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684049cc36fc832cb788f8b18feb1603