### PR TITLE
Add dashboard links

### DIFF
--- a/templates/admin/messages_management.html
+++ b/templates/admin/messages_management.html
@@ -4,8 +4,15 @@
 {% block content %}
 <div class="row mb-4">
     <div class="col-12">
-        <h1 class="h3 mb-1">Messages Management</h1>
-        <p class="text-muted mb-0">Review all messages submitted by guests</p>
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="h3 mb-1">Messages Management</h1>
+                <p class="text-muted mb-0">Review all messages submitted by guests</p>
+            </div>
+            <a href="/admin/dashboard" class="btn btn-outline-secondary">
+                <i class="fas fa-arrow-left me-1"></i> Back to Dashboard
+            </a>
+        </div>
         <form method="get" class="my-3">
             <div class="input-group">
                 <input type="text" class="form-control" name="q" value="{{ search_query or '' }}" placeholder="Search by guest name, phone or message...">

--- a/templates/check_in.html
+++ b/templates/check_in.html
@@ -198,8 +198,8 @@
                 {% endif %}
                 
                 <div class="text-center mt-4">
-                    <a href="/" class="btn btn-outline-secondary">
-                        <i class="fas fa-arrow-left me-2"></i> Back to Home
+                    <a href="/admin/dashboard" class="btn btn-outline-secondary">
+                        <i class="fas fa-arrow-left me-2"></i> Back to Dashboard
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add a back to dashboard link on Messages Management page
- change the check-in page link to point to admin dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840828cc3c0832cb635c46c75969e79