### PR TITLE
Add help blocks to admin pages

### DIFF
--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -384,6 +384,18 @@
         </div>
     </div>
 </div>
+
+<div class="row mt-5">
+    <div class="col-12">
+        <div class="card bg-light border-0">
+            <div class="card-body">
+                <h5 class="card-title">How this page fits in</h5>
+                <p class="mb-1">This dashboard shows a quick snapshot of guest numbers and activity.</p>
+                <p class="mb-0">Use the buttons above to manage registrations, meals, gifts and more. Each section works together so everyone stays updated.</p>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/admin/food_management.html
+++ b/templates/admin/food_management.html
@@ -427,6 +427,18 @@
 }
 </style>
 
+<div class="row mt-5">
+    <div class="col-12">
+        <div class="card bg-light border-0">
+            <div class="card-body">
+                <h5 class="card-title">How this page fits in</h5>
+                <p class="mb-1">Use this screen to hand out meal coupons quickly and check who has them.</p>
+                <p class="mb-0">The records link with guest check-in so every team knows who is eating on each day.</p>
+            </div>
+        </div>
+    </div>
+</div>
+
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/admin/gift_management.html
+++ b/templates/admin/gift_management.html
@@ -304,6 +304,17 @@
         </div>
     </div>
 </div>
+<div class="row mt-5">
+    <div class="col-12">
+        <div class="card bg-light border-0">
+            <div class="card-body">
+                <h5 class="card-title">How this page fits in</h5>
+                <p class="mb-1">Here you mark when guests pick up their conference gifts.</p>
+                <p class="mb-0">These updates sync with the registration desk so gifts are not given twice.</p>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/admin/journey_management.html
+++ b/templates/admin/journey_management.html
@@ -285,6 +285,17 @@
         </div>
     </div>
 </div>
+<div class="row mt-5">
+    <div class="col-12">
+        <div class="card bg-light border-0">
+            <div class="card-body">
+                <h5 class="card-title">How this page fits in</h5>
+                <p class="mb-1">Update and track each guest's travel plans here.</p>
+                <p class="mb-0">These details connect to their profiles so the transport team and organizers see the same information.</p>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/admin/presentations_management.html
+++ b/templates/admin/presentations_management.html
@@ -41,4 +41,15 @@
         </div>
     </div>
 </div>
+<div class="row mt-5">
+    <div class="col-12">
+        <div class="card bg-light border-0">
+            <div class="card-body">
+                <h5 class="card-title">How this page fits in</h5>
+                <p class="mb-1">This list shows all presentations uploaded by guests.</p>
+                <p class="mb-0">Files here feed into the program schedule so you can easily download and review them.</p>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- explain how dashboard integrates with other tools
- provide user-friendly help on food, gift, journey and presentation pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684094a76c9c832cb556fa3dd9d8fbfc