### PR TITLE
Add admin email client

### DIFF
--- a/email_config.ini
+++ b/email_config.ini
@@ -1,0 +1,7 @@
+[EMAIL]
+SMTPServer = smtp.example.com
+SMTPPort = 587
+Username = user@example.com
+Password = changeme
+SenderEmail = noreply@example.com
+SenderName = Conference Admin

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -224,6 +224,13 @@
                     </div>
 
                     <div class="col-md-4 mb-3">
+                        <a href="/admin/email_client" class="btn btn-outline-primary w-100 h-100 d-flex flex-column align-items-center justify-content-center py-4">
+                            <i class="fas fa-paper-plane fa-2x mb-2"></i>
+                            <span>Send Emails</span>
+                        </a>
+                    </div>
+
+                    <div class="col-md-4 mb-3">
                         <a href="/admin/report" class="btn btn-secondary w-100 h-100 d-flex flex-column align-items-center justify-content-center py-4">
                             <i class="fas fa-chart-bar fa-2x mb-2"></i>
                             <span>View Reports</span>

--- a/templates/admin/email_client.html
+++ b/templates/admin/email_client.html
@@ -1,0 +1,101 @@
+{% extends "base.html" %}
+{% block title %}Email Client | Conference Management{% endblock %}
+
+{% block content %}
+<div class="row mb-4">
+    <div class="col-12 d-flex justify-content-between align-items-center">
+        <h1 class="h3 mb-0">Send Email</h1>
+        <a href="/admin/dashboard" class="btn btn-outline-secondary">Back to Dashboard</a>
+    </div>
+</div>
+
+<form method="post" action="/admin/send-email" enctype="multipart/form-data" class="mb-4">
+    <div class="row">
+        <div class="col-md-4">
+            <label class="form-label">Recipients</label>
+            <select name="recipient_ids" multiple class="form-select">
+                {% for g in guests %}
+                <option value="{{ g.ID }}">{{ g.Name }} ({{ g.ID }})</option>
+                {% endfor %}
+            </select>
+            <small class="text-muted">Leave empty to use role filter or send to all.</small>
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">Role</label>
+            <select name="recipient_role" class="form-select">
+                <option value="">All</option>
+                {% for r in roles %}
+                <option value="{{ r }}">{{ r }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">Category</label>
+            <select name="category" class="form-select" required>
+                {% for c in categories %}
+                <option value="{{ c }}">{{ c }}</option>
+                {% endfor %}
+            </select>
+        </div>
+    </div>
+    <div class="row mt-3">
+        <div class="col-md-6">
+            <label class="form-label">Subject</label>
+            <input type="text" name="subject" class="form-control" required>
+        </div>
+        <div class="col-md-6">
+            <label class="form-label">Attachment</label>
+            <input type="file" name="attachment" class="form-control">
+        </div>
+    </div>
+    <div class="mt-3">
+        <label class="form-label">Message</label>
+        <textarea name="message" class="form-control" rows="6" required></textarea>
+    </div>
+    <div class="mt-3 text-end">
+        <button type="submit" class="btn btn-primary">Send Email</button>
+    </div>
+</form>
+
+<h5>Email Statistics</h5>
+<table class="table table-bordered">
+    <thead><tr><th>Category</th><th>Count</th></tr></thead>
+    <tbody>
+    {% for cat, count in stats.items() %}
+        <tr><td>{{ cat }}</td><td>{{ count }}</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+<h5 class="mt-4">Sent Emails</h5>
+<div class="table-responsive">
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Timestamp</th>
+            <th>Recipients</th>
+            <th>Category</th>
+            <th>Subject</th>
+            <th>Attachment</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for e in emails %}
+        <tr>
+            <td>{{ e.timestamp }}</td>
+            <td>{{ e.recipients }}</td>
+            <td>{{ e.category }}</td>
+            <td>{{ e.subject }}</td>
+            <td>
+                {% if e.attachment %}
+                <a href="{{ '/static/uploads/email_attachments/' + e.attachment }}" target="_blank">{{ e.attachment }}</a>
+                {% else %}-{% endif %}
+            </td>
+        </tr>
+        {% else %}
+        <tr><td colspan="5" class="text-center">No emails sent.</td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- configure SMTP parameters in `email_config.ini`
- extend email service with attachment support
- add email client routes and logging
- create dashboard button and HTML template for sending emails

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68409a7f50a8832cb4ad6f3fb9a32edc