### PR TITLE
Improve email client UI and add templates

### DIFF
--- a/email_templates/certificate.txt
+++ b/email_templates/certificate.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Certificate email template.
+
+Regards,
+Conference Team

--- a/email_templates/conference_day_1.txt
+++ b/email_templates/conference_day_1.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the conference day 1 email template.
+
+Regards,
+Conference Team

--- a/email_templates/conference_day_2.txt
+++ b/email_templates/conference_day_2.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the conference day 2 email template.
+
+Regards,
+Conference Team

--- a/email_templates/introduction.txt
+++ b/email_templates/introduction.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Introduction email template.
+
+Regards,
+Conference Team

--- a/email_templates/post_conference_1.txt
+++ b/email_templates/post_conference_1.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Post Conference 1 email template.
+
+Regards,
+Conference Team

--- a/email_templates/post_conference_2.txt
+++ b/email_templates/post_conference_2.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Post Conference 2 email template.
+
+Regards,
+Conference Team

--- a/email_templates/pre-conf_info_2.txt
+++ b/email_templates/pre-conf_info_2.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the pre-conf info 2 email template.
+
+Regards,
+Conference Team

--- a/email_templates/pre-conference_info1.txt
+++ b/email_templates/pre-conference_info1.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the pre-conference info1 email template.
+
+Regards,
+Conference Team

--- a/email_templates/rsvp_of_conference.txt
+++ b/email_templates/rsvp_of_conference.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the RSVP of Conference email template.
+
+Regards,
+Conference Team

--- a/email_templates/schedule_of_conference.txt
+++ b/email_templates/schedule_of_conference.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Schedule of conference email template.
+
+Regards,
+Conference Team

--- a/email_templates/speaker_info_1.txt
+++ b/email_templates/speaker_info_1.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Speaker info 1 email template.
+
+Regards,
+Conference Team

--- a/email_templates/speaker_info_2.txt
+++ b/email_templates/speaker_info_2.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Speaker info 2 email template.
+
+Regards,
+Conference Team

--- a/email_templates/sponsor_info1.txt
+++ b/email_templates/sponsor_info1.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Sponsor info1 email template.
+
+Regards,
+Conference Team

--- a/email_templates/sponsor_info2.txt
+++ b/email_templates/sponsor_info2.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Sponsor Info2 email template.
+
+Regards,
+Conference Team

--- a/email_templates/thank_you.txt
+++ b/email_templates/thank_you.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Thank you email template.
+
+Regards,
+Conference Team

--- a/templates/admin/email_client.html
+++ b/templates/admin/email_client.html
@@ -13,7 +13,12 @@
     <div class="row">
         <div class="col-md-4">
             <label class="form-label">Recipients</label>
-            <select name="recipient_ids" multiple class="form-select">
+            <input type="text" id="recipientSearch" class="form-control mb-2" placeholder="Search recipients">
+            <div class="mb-2">
+                <button type="button" id="selectAllRecipients" class="btn btn-sm btn-outline-primary me-2">Select All</button>
+                <button type="button" id="clearAllRecipients" class="btn btn-sm btn-outline-secondary">Clear</button>
+            </div>
+            <select id="recipientSelect" name="recipient_ids" multiple class="form-select" size="8">
                 {% for g in guests %}
                 <option value="{{ g.ID }}">{{ g.Name }} ({{ g.ID }})</option>
                 {% endfor %}
@@ -31,7 +36,7 @@
         </div>
         <div class="col-md-4">
             <label class="form-label">Category</label>
-            <select name="category" class="form-select" required>
+            <select id="categorySelect" name="category" class="form-select" required>
                 {% for c in categories %}
                 <option value="{{ c }}">{{ c }}</option>
                 {% endfor %}
@@ -50,7 +55,7 @@
     </div>
     <div class="mt-3">
         <label class="form-label">Message</label>
-        <textarea name="message" class="form-control" rows="6" required></textarea>
+        <textarea id="messageInput" name="message" class="form-control" rows="6" required></textarea>
     </div>
     <div class="mt-3 text-end">
         <button type="submit" class="btn btn-primary">Send Email</button>
@@ -98,4 +103,63 @@
     </tbody>
 </table>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const searchInput = document.getElementById('recipientSearch');
+    const select = document.getElementById('recipientSelect');
+    const selectAllBtn = document.getElementById('selectAllRecipients');
+    const clearBtn = document.getElementById('clearAllRecipients');
+    const categorySelect = document.getElementById('categorySelect');
+    const messageInput = document.getElementById('messageInput');
+
+    if (searchInput) {
+        searchInput.addEventListener('input', function() {
+            const filter = this.value.toLowerCase();
+            Array.from(select.options).forEach(opt => {
+                const text = opt.textContent.toLowerCase();
+                opt.style.display = text.includes(filter) ? '' : 'none';
+            });
+        });
+    }
+
+    if (selectAllBtn) {
+        selectAllBtn.addEventListener('click', function() {
+            Array.from(select.options).forEach(opt => {
+                if (opt.style.display !== 'none') opt.selected = true;
+            });
+        });
+    }
+
+    if (clearBtn) {
+        clearBtn.addEventListener('click', function() {
+            Array.from(select.options).forEach(opt => {
+                opt.selected = false;
+            });
+        });
+    }
+
+    async function loadTemplate(cat) {
+        if (!cat) return;
+        try {
+            const resp = await fetch(`/admin/email_template/${encodeURIComponent(cat)}`);
+            if (resp.ok) {
+                const data = await resp.json();
+                messageInput.value = data.template || '';
+            }
+        } catch (e) {
+            console.error('Template load error', e);
+        }
+    }
+
+    if (categorySelect) {
+        loadTemplate(categorySelect.value);
+        categorySelect.addEventListener('change', function() {
+            loadTemplate(this.value);
+        });
+    }
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enhance recipient selection with search, select all and clear buttons
- auto-load email templates based on category
- add endpoint to serve email templates
- ship sample templates for all categories

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841f2a00834832c82eb44bde9a2f3e2