### PR TITLE
Improve email client UI and add templates

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -5,6 +5,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 from typing import Optional, List, Dict
 import logging
 import os
+import re
 from datetime import datetime
 from collections import defaultdict
 from pathlib import Path
@@ -63,6 +64,8 @@ email_service = EmailService(
 EMAIL_LOG_CSV = os.path.join(os.path.dirname(config.get('DATABASE', 'CSVPath')), 'emails.csv')
 EMAIL_ATTACH_DIR = os.path.join(config.get('PATHS', 'StaticDir'), 'uploads/email_attachments')
 os.makedirs(EMAIL_ATTACH_DIR, exist_ok=True)
+EMAIL_TEMPLATE_DIR = os.path.join('email_templates')
+os.makedirs(EMAIL_TEMPLATE_DIR, exist_ok=True)
 
 # Allowed categories for outgoing emails
 EMAIL_CATEGORIES = [
@@ -71,6 +74,35 @@ EMAIL_CATEGORIES = [
     'RSVP of Conference', 'conference day 1', 'conference day 2', 'Thank you',
     'Certificate', 'Post Conference 1', 'Post Conference 2'
 ]
+
+
+def get_email_client_context(request: Request) -> Dict:
+    """Build context data for the email client page"""
+    guests = guests_db.read_all()
+    roles = sorted(set(g.get("GuestRole", "") for g in guests))
+
+    emails = []
+    if os.path.exists(EMAIL_LOG_CSV):
+        with open(EMAIL_LOG_CSV, newline="", encoding="utf-8") as f:
+            emails = list(csv.DictReader(f))
+
+    stats = {c: 0 for c in EMAIL_CATEGORIES}
+    for e in emails:
+        cat = e.get("category")
+        if cat in stats:
+            stats[cat] += 1
+
+    emails = sorted(emails, key=lambda x: x.get("timestamp", ""), reverse=True)
+
+    return {
+        "request": request,
+        "guests": guests,
+        "roles": roles,
+        "emails": emails,
+        "categories": EMAIL_CATEGORIES,
+        "stats": stats,
+        "active_page": "email_client",
+    }
 
 @router.get("/dashboard", response_class=HTMLResponse)
 async def admin_dashboard(request: Request, admin: Dict = Depends(get_current_admin)):
@@ -227,7 +259,7 @@ async def send_email_to_guests(
     subject: str = Form(...),
     message: str = Form(...),
     recipient_role: Optional[str] = Form(None),
-    recipient_ids: Optional[str] = Form(None),
+    recipient_ids: Optional[List[str]] = Form(None),
     category: str = Form(...),
     attachment: UploadFile = File(None)
 ):
@@ -239,11 +271,11 @@ async def send_email_to_guests(
         subject: Email subject
         message: Email message body (HTML)
         recipient_role: Optional role to filter recipients
-        recipient_ids: Optional comma-separated list of guest IDs
+        recipient_ids: Optional list of guest IDs
         category: Category of the email
         attachment: Optional file attachment
     Returns:
-        JSONResponse: Result of email sending operation
+        TemplateResponse: Rendered email client page with status message
     """
     try:
         # Get recipients based on criteria
@@ -252,11 +284,16 @@ async def send_email_to_guests(
         recipient_ids_list = []
 
         if category not in EMAIL_CATEGORIES:
-            return JSONResponse(status_code=400, content={"success": False, "message": "Invalid category"})
+            context = get_email_client_context(request)
+            context.update({
+                "result_message": "Invalid category selected", 
+                "result_success": False
+            })
+            return templates.TemplateResponse("admin/email_client.html", context, status_code=400)
         
         if recipient_ids:
             # Send to specific guests
-            guest_ids = [id.strip() for id in recipient_ids.split(',')]
+            guest_ids = [id.strip() for id in recipient_ids]
             recipient_ids_list = guest_ids
             recipients = [
                 guest["Email"] for guest in guests
@@ -277,10 +314,12 @@ async def send_email_to_guests(
             recipient_ids_list = [g["ID"] for g in guests if g.get("Email")]
         
         if not recipients:
-            return JSONResponse(
-                status_code=400,
-                content={"success": False, "message": "No valid recipients found"}
-            )
+            context = get_email_client_context(request)
+            context.update({
+                "result_message": "No valid recipients found",
+                "result_success": False
+            })
+            return templates.TemplateResponse("admin/email_client.html", context, status_code=400)
         
         # Save attachment if provided
         attachment_path = None
@@ -320,51 +359,40 @@ async def send_email_to_guests(
                 writer.writeheader()
             writer.writerow(row)
         
-        return JSONResponse(content={
-            "success": True,
-            "message": f"Sent {successes} emails successfully. {failures} failed.",
-            "details": {
-                "total": len(results),
-                "success": successes,
-                "failed": failures
-            }
+        context = get_email_client_context(request)
+        context.update({
+            "result_message": f"Sent {successes} emails successfully. {failures} failed.",
+            "result_success": True
         })
+        return templates.TemplateResponse("admin/email_client.html", context)
     except Exception as e:
         logger.error(f"Error sending emails: {str(e)}", exc_info=True)
-        return JSONResponse(
-            status_code=500,
-            content={"success": False, "message": f"Error sending emails: {str(e)}"}
+        return templates.TemplateResponse(
+            "error.html",
+            {
+                "request": request,
+                "message": "Error sending emails",
+                "error_details": str(e) if config.getboolean('DEFAULT', 'Debug', fallback=False) else None
+            },
+            status_code=500
         )
+
+@router.get("/email_template/{category}")
+async def get_email_template(category: str, admin: Dict = Depends(get_current_admin)):
+    """Return the email template content for the given category"""
+    sanitized = re.sub(r"[^a-zA-Z0-9_-]", "_", category.strip().lower())
+    template_path = os.path.join(EMAIL_TEMPLATE_DIR, f"{sanitized}.txt")
+    if os.path.exists(template_path):
+        with open(template_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        return JSONResponse(content={"template": content})
+    return JSONResponse(content={"template": ""})
 
 @router.get("/email_client", response_class=HTMLResponse)
 async def email_client_page(request: Request, admin: Dict = Depends(get_current_admin)):
     """Interface for sending emails and viewing history"""
-    guests = guests_db.read_all()
-    roles = sorted(set(g.get("GuestRole", "") for g in guests))
-    emails = []
-    if os.path.exists(EMAIL_LOG_CSV):
-        with open(EMAIL_LOG_CSV, newline="", encoding="utf-8") as f:
-            emails = list(csv.DictReader(f))
-
-    stats = {c: 0 for c in EMAIL_CATEGORIES}
-    for e in emails:
-        cat = e.get("category")
-        if cat in stats:
-            stats[cat] += 1
-    emails = sorted(emails, key=lambda x: x.get("timestamp", ""), reverse=True)
-
-    return templates.TemplateResponse(
-        "admin/email_client.html",
-        {
-            "request": request,
-            "guests": guests,
-            "roles": roles,
-            "emails": emails,
-            "categories": EMAIL_CATEGORIES,
-            "stats": stats,
-            "active_page": "email_client",
-        },
-    )
+    context = get_email_client_context(request)
+    return templates.TemplateResponse("admin/email_client.html", context)
 
 @router.get("/admin_dashboard", response_class=HTMLResponse)
 async def admin_dashboard_page(request: Request, admin: Dict = Depends(get_current_admin)):

--- a/email_templates/certificate.txt
+++ b/email_templates/certificate.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Certificate email template.
+
+Regards,
+Conference Team

--- a/email_templates/conference_day_1.txt
+++ b/email_templates/conference_day_1.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the conference day 1 email template.
+
+Regards,
+Conference Team

--- a/email_templates/conference_day_2.txt
+++ b/email_templates/conference_day_2.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the conference day 2 email template.
+
+Regards,
+Conference Team

--- a/email_templates/introduction.txt
+++ b/email_templates/introduction.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Introduction email template.
+
+Regards,
+Conference Team

--- a/email_templates/post_conference_1.txt
+++ b/email_templates/post_conference_1.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Post Conference 1 email template.
+
+Regards,
+Conference Team

--- a/email_templates/post_conference_2.txt
+++ b/email_templates/post_conference_2.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Post Conference 2 email template.
+
+Regards,
+Conference Team

--- a/email_templates/pre-conf_info_2.txt
+++ b/email_templates/pre-conf_info_2.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the pre-conf info 2 email template.
+
+Regards,
+Conference Team

--- a/email_templates/pre-conference_info1.txt
+++ b/email_templates/pre-conference_info1.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the pre-conference info1 email template.
+
+Regards,
+Conference Team

--- a/email_templates/rsvp_of_conference.txt
+++ b/email_templates/rsvp_of_conference.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the RSVP of Conference email template.
+
+Regards,
+Conference Team

--- a/email_templates/schedule_of_conference.txt
+++ b/email_templates/schedule_of_conference.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Schedule of conference email template.
+
+Regards,
+Conference Team

--- a/email_templates/speaker_info_1.txt
+++ b/email_templates/speaker_info_1.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Speaker info 1 email template.
+
+Regards,
+Conference Team

--- a/email_templates/speaker_info_2.txt
+++ b/email_templates/speaker_info_2.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Speaker info 2 email template.
+
+Regards,
+Conference Team

--- a/email_templates/sponsor_info1.txt
+++ b/email_templates/sponsor_info1.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Sponsor info1 email template.
+
+Regards,
+Conference Team

--- a/email_templates/sponsor_info2.txt
+++ b/email_templates/sponsor_info2.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Sponsor Info2 email template.
+
+Regards,
+Conference Team

--- a/email_templates/thank_you.txt
+++ b/email_templates/thank_you.txt
@@ -1,0 +1,6 @@
+Dear Guest,
+
+This is the Thank you email template.
+
+Regards,
+Conference Team

--- a/templates/admin/email_client.html
+++ b/templates/admin/email_client.html
@@ -9,11 +9,23 @@
     </div>
 </div>
 
+{% if result_message %}
+<div class="alert alert-{{ 'success' if result_success else 'danger' }} alert-dismissible fade show" role="alert">
+    {{ result_message }}
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>
+{% endif %}
+
 <form method="post" action="/admin/send-email" enctype="multipart/form-data" class="mb-4">
     <div class="row">
         <div class="col-md-4">
             <label class="form-label">Recipients</label>
-            <select name="recipient_ids" multiple class="form-select">
+            <input type="text" id="recipientSearch" class="form-control mb-2" placeholder="Search recipients">
+            <div class="mb-2">
+                <button type="button" id="selectAllRecipients" class="btn btn-sm btn-outline-primary me-2">Select All</button>
+                <button type="button" id="clearAllRecipients" class="btn btn-sm btn-outline-secondary">Clear</button>
+            </div>
+            <select id="recipientSelect" name="recipient_ids" multiple class="form-select" size="8">
                 {% for g in guests %}
                 <option value="{{ g.ID }}">{{ g.Name }} ({{ g.ID }})</option>
                 {% endfor %}
@@ -31,7 +43,7 @@
         </div>
         <div class="col-md-4">
             <label class="form-label">Category</label>
-            <select name="category" class="form-select" required>
+            <select id="categorySelect" name="category" class="form-select" required>
                 {% for c in categories %}
                 <option value="{{ c }}">{{ c }}</option>
                 {% endfor %}
@@ -50,7 +62,7 @@
     </div>
     <div class="mt-3">
         <label class="form-label">Message</label>
-        <textarea name="message" class="form-control" rows="6" required></textarea>
+        <textarea id="messageInput" name="message" class="form-control" rows="6" required></textarea>
     </div>
     <div class="mt-3 text-end">
         <button type="submit" class="btn btn-primary">Send Email</button>
@@ -98,4 +110,63 @@
     </tbody>
 </table>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const searchInput = document.getElementById('recipientSearch');
+    const select = document.getElementById('recipientSelect');
+    const selectAllBtn = document.getElementById('selectAllRecipients');
+    const clearBtn = document.getElementById('clearAllRecipients');
+    const categorySelect = document.getElementById('categorySelect');
+    const messageInput = document.getElementById('messageInput');
+
+    if (searchInput) {
+        searchInput.addEventListener('input', function() {
+            const filter = this.value.toLowerCase();
+            Array.from(select.options).forEach(opt => {
+                const text = opt.textContent.toLowerCase();
+                opt.style.display = text.includes(filter) ? '' : 'none';
+            });
+        });
+    }
+
+    if (selectAllBtn) {
+        selectAllBtn.addEventListener('click', function() {
+            Array.from(select.options).forEach(opt => {
+                if (opt.style.display !== 'none') opt.selected = true;
+            });
+        });
+    }
+
+    if (clearBtn) {
+        clearBtn.addEventListener('click', function() {
+            Array.from(select.options).forEach(opt => {
+                opt.selected = false;
+            });
+        });
+    }
+
+    async function loadTemplate(cat) {
+        if (!cat) return;
+        try {
+            const resp = await fetch(`/admin/email_template/${encodeURIComponent(cat)}`);
+            if (resp.ok) {
+                const data = await resp.json();
+                messageInput.value = data.template || '';
+            }
+        } catch (e) {
+            console.error('Template load error', e);
+        }
+    }
+
+    if (categorySelect) {
+        loadTemplate(categorySelect.value);
+        categorySelect.addEventListener('change', function() {
+            loadTemplate(this.value);
+        });
+    }
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enhance recipient selection with search, select all and clear buttons
- auto-load email templates based on category
- add endpoint to serve email templates
- ship sample templates for all categories
- improve handling of email form with feedback and error pages

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6841f2a00834832c82eb44bde9a2f3e2