### PR TITLE
Allow admins to message guests

### DIFF
--- a/templates/admin/messages_management.html
+++ b/templates/admin/messages_management.html
@@ -19,6 +19,21 @@
                 <button class="btn btn-outline-secondary" type="submit"><i class="fas fa-search"></i> Search</button>
             </div>
         </form>
+        <form method="post" action="/admin/send_message" class="row g-2 mb-3">
+            <div class="col-md-3">
+                <select name="guest_id" class="form-select" required>
+                    {% for guest in guests %}
+                    <option value="{{ guest.ID }}">{{ guest.Name }} ({{ guest.ID }})</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md">
+                <input type="text" name="message" class="form-control" placeholder="Message to guest" required>
+            </div>
+            <div class="col-md-auto">
+                <button class="btn btn-primary" type="submit">Send Message</button>
+            </div>
+        </form>
         <div class="table-responsive mt-4">
             <table class="table table-bordered table-hover">
                 <thead class="table-light">

--- a/templates/guest/profile.html
+++ b/templates/guest/profile.html
@@ -320,7 +320,9 @@
                                 {% for msg in messages %}
                                 <div class="mb-3 border rounded p-2">
                                     <div class="small text-muted">{{ msg.timestamp }}</div>
+                                    {% if msg.message %}
                                     <p class="mb-1">{{ msg.message }}</p>
+                                    {% endif %}
                                     {% if msg.response %}
                                     <div class="bg-light p-2 mt-2 rounded">
                                         <strong>Admin:</strong> {{ msg.response }}


### PR DESCRIPTION
## Summary
- allow filtering messages by guest and provide list of guests
- add a new admin route to send messages
- show send-message form in the admin messages page
- display admin-only messages in guest profile

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684202c4a7a4832c8df8820b2ce5973a