### PR TITLE
Implement schedule download on guest profile

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -55,7 +55,8 @@ required_directories = [
     os.path.join(config.get('PATHS', 'StaticDir'), "uploads"),
     os.path.join(config.get('PATHS', 'StaticDir'), "uploads/presentations"),
     os.path.join(config.get('PATHS', 'StaticDir'), "uploads/profile_photos"),
-    os.path.join(config.get('PATHS', 'StaticDir'), "qr_codes")
+    os.path.join(config.get('PATHS', 'StaticDir'), "qr_codes"),
+    os.path.join(config.get('PATHS', 'StaticDir'), "schedule")
 ]
 
 for directory in required_directories:

--- a/templates/guest/profile.html
+++ b/templates/guest/profile.html
@@ -380,9 +380,12 @@
                             </div>
                             
                             <div class="text-center mt-3">
-                                <button class="btn btn-outline-primary">
+                                <a href="/static/schedule/conference_schedule.pdf" 
+                                   class="btn btn-outline-primary" 
+                                   target="_blank" 
+                                   download="MAGNACODE2025_Schedule.pdf">
                                     <i class="fas fa-download me-1"></i>Download Full Schedule
-                                </button>
+                                </a>
                             </div>
                             
                             <!-- Additional Conference Info -->


### PR DESCRIPTION
## Summary
- create schedule directory during startup
- add download link for conference schedule PDF on guest profile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be85b0258832cba932bb1aed0238d