### PR TITLE
Fix Jinja include syntax

### DIFF
--- a/templates/admin/all_guests.html
+++ b/templates/admin/all_guests.html
@@ -159,7 +159,8 @@
                                             </div>
                                         </td>
                                         <td>
-                                            {% include 'components/payment_status.html' with status=guest.PaymentStatus|lower %}
+                                            {% set status = guest.PaymentStatus|lower %}
+                                            {% include 'components/payment_status.html' %}
                                         </td>
                                         <td>
                                             <div class="btn-group btn-group-sm">


### PR DESCRIPTION
## Summary
- fix Jinja include syntax in `all_guests.html` so templates render correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bf3251b54832c9f26f842e934fcbe