### PR TITLE
Add basic payment management UI and routes

### DIFF
--- a/templates/admin/payment_config.html
+++ b/templates/admin/payment_config.html
@@ -2,24 +2,57 @@
 {% block title %}Payment Configuration{% endblock %}
 {% block content %}
 <h1 class="h4 mb-4">Payment Configuration</h1>
-<table class="table table-bordered">
-    <thead>
-        <tr>
-            <th>Role</th>
-            <th>Required</th>
-            <th>Amount</th>
-            <th>Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for cfg in configs %}
-        <tr>
-            <td>{{ cfg.role }}</td>
-            <td>{{ cfg.payment_required }}</td>
-            <td>{{ cfg.amount }}</td>
-            <td>{{ cfg.description }}</td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
+<div class="table-responsive mb-4">
+    <table class="table table-bordered">
+        <thead class="table-light">
+            <tr>
+                <th>Role</th>
+                <th>Required</th>
+                <th>Amount</th>
+                <th>Description</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for cfg in configs %}
+            <tr>
+                <form method="post" action="/payment/config/update" class="row g-2 align-items-center">
+                    <input type="hidden" name="role" value="{{ cfg.role }}">
+                    <td class="col-md-2">{{ cfg.role }}</td>
+                    <td class="col-md-2 text-center">
+                        <input type="checkbox" name="payment_required" value="True" {% if cfg.payment_required %}checked{% endif %}>
+                    </td>
+                    <td class="col-md-2">
+                        <input type="number" step="0.01" name="amount" value="{{ cfg.amount }}" class="form-control form-control-sm">
+                    </td>
+                    <td class="col-md-4">
+                        <input type="text" name="description" value="{{ cfg.description }}" class="form-control form-control-sm">
+                    </td>
+                    <td class="col-md-2 text-center">
+                        <button type="submit" class="btn btn-sm btn-primary">Save</button>
+                    </td>
+                </form>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+<h5>Add New Role</h5>
+<form method="post" action="/payment/config/update" class="row g-2">
+    <div class="col-md-2">
+        <input type="text" class="form-control form-control-sm" name="role" placeholder="Role" required>
+    </div>
+    <div class="col-md-2 text-center">
+        <input type="checkbox" name="payment_required" value="True">
+    </div>
+    <div class="col-md-2">
+        <input type="number" step="0.01" name="amount" class="form-control form-control-sm" value="0">
+    </div>
+    <div class="col-md-4">
+        <input type="text" name="description" class="form-control form-control-sm">
+    </div>
+    <div class="col-md-2 text-center">
+        <button type="submit" class="btn btn-sm btn-success">Add</button>
+    </div>
+</form>
 {% endblock %}

--- a/templates/admin/payment_management.html
+++ b/templates/admin/payment_management.html
@@ -5,7 +5,32 @@
 <div class="mb-3">
     <strong>Total Payments:</strong> {{ stats.total_payments }} |
     <strong>Total Amount:</strong> ₹{{ stats.total_amount }}
+    <a href="/payment/export" class="btn btn-sm btn-outline-secondary ms-3">Export CSV</a>
 </div>
+<h5 class="mb-3">Record Payment</h5>
+<form method="post" action="/payment/record" enctype="multipart/form-data" class="row g-2 mb-4">
+    <div class="col-md-2">
+        <input type="text" name="guest_id" class="form-control form-control-sm" placeholder="Guest ID" required>
+    </div>
+    <div class="col-md-2">
+        <input type="number" step="0.01" name="amount" class="form-control form-control-sm" placeholder="Amount" required>
+    </div>
+    <div class="col-md-2">
+        <select name="payment_method" class="form-select form-select-sm">
+            <option value="cash">Cash</option>
+            <option value="card">Card</option>
+            <option value="upi">UPI</option>
+            <option value="bank_transfer">Bank Transfer</option>
+            <option value="online">Online</option>
+        </select>
+    </div>
+    <div class="col-md-3">
+        <input type="file" name="payment_proof" class="form-control form-control-sm">
+    </div>
+    <div class="col-md-3 text-end">
+        <button type="submit" class="btn btn-sm btn-primary">Record</button>
+    </div>
+</form>
 <table class="table table-striped">
     <thead>
         <tr>

--- a/templates/components/navbar.html
+++ b/templates/components/navbar.html
@@ -68,6 +68,11 @@
                             </a>
                         </li>
                         <li>
+                            <a class="dropdown-item" href="/payment/config">
+                                <i class="fas fa-cog"></i> Payment Settings
+                            </a>
+                        </li>
+                        <li>
                             <a class="dropdown-item" href="/report">
                                 <i class="fas fa-chart-bar"></i> Reports
                             </a>

--- a/templates/guest/profile.html
+++ b/templates/guest/profile.html
@@ -599,7 +599,11 @@
                             <h6 class="mb-0">Payments</h6>
                         </div>
                         <div class="card-body">
-                            <div class="table-responsive">
+                            <p>
+                                Required: ₹{{ payment_status.amount_required }} | Paid: ₹{{ payment_status.amount_paid }}
+                                {% include 'components/payment_status.html' with status=payment_status.status %}
+                            </p>
+                            <div class="table-responsive mb-3">
                                 <table class="table table-bordered">
                                     <thead class="table-light">
                                     <tr>
@@ -621,6 +625,26 @@
                                     </tbody>
                                 </table>
                             </div>
+                            <form method="post" action="/payment/record-guest" enctype="multipart/form-data" class="row g-2">
+                                <div class="col-md-4">
+                                    <input type="number" step="0.01" name="amount" class="form-control form-control-sm" placeholder="Amount" required>
+                                </div>
+                                <div class="col-md-3">
+                                    <select name="payment_method" class="form-select form-select-sm">
+                                        <option value="cash">Cash</option>
+                                        <option value="card">Card</option>
+                                        <option value="upi">UPI</option>
+                                        <option value="bank_transfer">Bank Transfer</option>
+                                        <option value="online">Online</option>
+                                    </select>
+                                </div>
+                                <div class="col-md-3">
+                                    <input type="file" name="payment_proof" class="form-control form-control-sm">
+                                </div>
+                                <div class="col-md-2 text-end">
+                                    <button type="submit" class="btn btn-sm btn-primary">Submit</button>
+                                </div>
+                            </form>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- integrate payment information on guest profile
- allow admins to manage payment config and payments
- add navbar link for payment settings
- enable guests to record payments and admins to export

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bf73ade44832ca5a75cba175667d5