### PR TITLE
Improve information & help card

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -389,21 +389,21 @@
                         <span><i class="fas fa-question-circle me-2"></i>How to Use This System</span>
                         <i class="fas fa-external-link-alt"></i>
                     </button>
-                    
-                    <button class="btn info-btn d-flex align-items-center justify-content-between">
+
+                    <button class="btn info-btn d-flex align-items-center justify-content-between" onclick="showVenueInfo()">
                         <span><i class="fas fa-map-marker-alt me-2"></i>Venue Information</span>
                         <i class="fas fa-external-link-alt"></i>
                     </button>
-                    
-                    <button class="btn info-btn d-flex align-items-center justify-content-between">
+
+                    <button class="btn info-btn d-flex align-items-center justify-content-between" onclick="showContactSupport()">
                         <span><i class="fas fa-phone me-2"></i>Contact Support</span>
                         <i class="fas fa-external-link-alt"></i>
                     </button>
-                    
-                    <button class="btn info-btn d-flex align-items-center justify-content-between">
+
+                    <a href="/static/schedule/conference_schedule.pdf" target="_blank" class="btn info-btn d-flex align-items-center justify-content-between text-decoration-none" download>
                         <span><i class="fas fa-calendar me-2"></i>Conference Schedule</span>
                         <i class="fas fa-download"></i>
-                    </button>
+                    </a>
                 </div>
                 
                 <!-- Conference Details -->
@@ -453,48 +453,6 @@
     </div>
 </div>
 
-<!-- Section Divider -->
-<div class="section-divider"></div>
-
-<!-- Additional Features Section -->
-<div class="row mt-4">
-    <div class="col-12">
-        <div class="card info-card">
-            <div class="card-body text-center p-4">
-                <h5 class="text-primary mb-3">
-                    <i class="fas fa-download me-2"></i>
-                    Conference Resources
-                </h5>
-                <div class="row g-3">
-                    <div class="col-lg-3 col-md-6 col-sm-6">
-                        <button class="btn info-btn w-100">
-                            <i class="fas fa-file-pdf me-2"></i>
-                            Complete Schedule
-                        </button>
-                    </div>
-                    <div class="col-lg-3 col-md-6 col-sm-6">
-                        <button class="btn info-btn w-100">
-                            <i class="fas fa-map me-2"></i>
-                            Venue Map
-                        </button>
-                    </div>
-                    <div class="col-lg-3 col-md-6 col-sm-6">
-                        <button class="btn info-btn w-100">
-                            <i class="fas fa-utensils me-2"></i>
-                            Meal Information
-                        </button>
-                    </div>
-                    <div class="col-lg-3 col-md-6 col-sm-6">
-                        <button class="btn info-btn w-100">
-                            <i class="fas fa-certificate me-2"></i>
-                            CPD Credits
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
 
 <!-- Help System Overlay -->
 {% include 'components/help_system.html' %}
@@ -554,6 +512,29 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 });
+
+// Information & Help Functions
+function showVenueInfo() {
+    alert(`Venue Information:
+    
+📍 The Chancery Pavilion, Bangalore
+🕘 Conference Hours: 09:00 AM to 6:25 PM
+📅 Dates: September 20-21, 2025
+🚗 Parking: Available on-site
+📞 Venue Contact: +91-80-4277-7777`);
+}
+
+function showContactSupport() {
+    alert(`Contact Support:
+    
+📞 Primary Contact: 6369855704
+📞 Secondary Contact: 9606609785
+📧 Email: info@magnacodes.com
+🕐 Support Hours: 24/7 during conference days
+💬 WhatsApp Support Available
+    
+For technical issues with the system, please call the primary contact number.`);
+}
 
 // Add ripple animation
 const style = document.createElement('style');


### PR DESCRIPTION
## Summary
- cleanup index page by removing the unused "Conference Resources" section
- expand information & help with venue details, support contacts and schedule link
- add JS helpers `showVenueInfo()` and `showContactSupport()`

## Testing
- `python -m compileall -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859758676e8832c9289499232bcee59