### PR TITLE
Add schedule overview to homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -359,17 +359,75 @@
                     </div>
                 </div>
                 
-                <!-- Quick Check-in Feature -->
-                <div class="feature-highlight text-center">
-                    <div class="mb-3">
-                        <i class="fas fa-qrcode fa-2x text-primary mb-2"></i>
-                        <h6 class="fw-bold text-primary mb-2">Quick Check-in Available</h6>
-                        <p class="small text-muted mb-3">Conference staff can scan guest QR codes for instant check-in</p>
+                <!-- Conference Schedule Overview -->
+                <div class="feature-highlight">
+                    <div class="text-center mb-3">
+                        <i class="fas fa-calendar-alt fa-2x text-primary mb-2"></i>
+                        <h6 class="fw-bold text-primary mb-2">Conference Schedule Overview</h6>
                     </div>
-                    <a href="/check_in" class="btn quick-scan-btn">
-                        <i class="fas fa-qrcode me-2"></i>
-                        <span class="fw-bold">Launch QR Scanner</span>
-                    </a>
+
+                    <div class="row g-2">
+                        <div class="col-md-6">
+                            <div class="border rounded p-3 h-100" style="background: linear-gradient(135deg, #e8f5e8 0%, #f0f8f0 100%); border-color: #28a745 !important;">
+                                <div class="d-flex align-items-center mb-2">
+                                    <div class="bg-success text-white rounded-circle d-flex align-items-center justify-content-center me-2" style="width: 24px; height: 24px; font-size: 0.75rem; font-weight: bold;">
+                                        1
+                                    </div>
+                                    <h6 class="mb-0 text-success fw-bold">Day 1 - Sep 20</h6>
+                                </div>
+                                <div class="small">
+                                    <div class="mb-1"><strong>09:00-11:30:</strong> MASLD &amp; Obesity</div>
+                                    <div class="mb-1"><strong>11:40-14:10:</strong> Nutrition &amp; Tech</div>
+                                    <div class="mb-0"><strong>14:55-18:25:</strong> GDM &amp; AI Medicine</div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="col-md-6">
+                            <div class="border rounded p-3 h-100" style="background: linear-gradient(135deg, #e3f2fd 0%, #f0f8ff 100%); border-color: #2196f3 !important;">
+                                <div class="d-flex align-items-center mb-2">
+                                    <div class="bg-primary text-white rounded-circle d-flex align-items-center justify-content-center me-2" style="width: 24px; height: 24px; font-size: 0.75rem; font-weight: bold;">
+                                        2
+                                    </div>
+                                    <h6 class="mb-0 text-primary fw-bold">Day 2 - Sep 21</h6>
+                                </div>
+                                <div class="small">
+                                    <div class="mb-1"><strong>09:00-11:30:</strong> PCOS &amp; Fertility</div>
+                                    <div class="mb-1"><strong>11:40-14:10:</strong> IVF &amp; Pediatric Endo</div>
+                                    <div class="mb-0"><strong>14:55-18:25:</strong> New Medications</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="text-center mt-3">
+                        <div class="row g-1">
+                            <div class="col-6 col-md-3">
+                                <div class="small">
+                                    <div class="fw-bold text-primary">20+</div>
+                                    <div class="text-muted small">Sessions</div>
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <div class="small">
+                                    <div class="fw-bold text-success">4</div>
+                                    <div class="text-muted small">CPD Credits</div>
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <div class="small">
+                                    <div class="fw-bold text-warning">2</div>
+                                    <div class="text-muted small">Days</div>
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <div class="small">
+                                    <div class="fw-bold text-info">9.5</div>
+                                    <div class="text-muted small">Hours/Day</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- replace quick check-in section on the index page with a conference schedule overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685980c95b30832ca0a32271c3eb0de4