### PR TITLE
Add logout links across admin pages and remove payment features

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -586,6 +586,14 @@ async def process_admin_login(
             }
         )
 
+@router.get("/logout")
+async def admin_logout(request: Request):
+    """Admin logout route"""
+    response = RedirectResponse(url="/", status_code=303)
+    response.delete_cookie("session_id")
+    log_activity("Admin", "Admin logged out")
+    return response
+
 @router.get("/report/export/guest_list")
 async def export_guest_list(
     admin: Dict = Depends(get_current_admin),

--- a/templates/admin/all_guests.html
+++ b/templates/admin/all_guests.html
@@ -53,6 +53,9 @@
                         <a href="/admin/guest_badges" class="btn btn-outline-secondary">
                             <i class="fas fa-id-badge me-1"></i> Badge Management
                         </a>
+                        <a href="/logout" class="btn btn-outline-secondary">
+                            <i class="fas fa-sign-out-alt me-1"></i> Logout
+                        </a>
                     </div>
                 </div>
             </div>

--- a/templates/admin/backup.html
+++ b/templates/admin/backup.html
@@ -1,4 +1,14 @@
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 
 {% block title %}Database Backups | Conference Management{% endblock %}
 

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -1,4 +1,14 @@
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 
 {% block title %}Admin Dashboard | Conference Management{% endblock %}
 

--- a/templates/admin/email_client.html
+++ b/templates/admin/email_client.html
@@ -1,4 +1,14 @@
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 {% block title %}Email Client | Conference Management{% endblock %}
 
 {% block content %}

--- a/templates/admin/food_management.html
+++ b/templates/admin/food_management.html
@@ -1,5 +1,15 @@
 <!-- templates/admin/food_management.html -->
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 
 {% block title %}Food Management | Conference Management{% endblock %}
 

--- a/templates/admin/gift_management.html
+++ b/templates/admin/gift_management.html
@@ -1,5 +1,15 @@
 <!-- templates/admin/gift_management.html -->
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 
 {% block title %}Gift Management | Conference Management{% endblock %}
 

--- a/templates/admin/guest_badges.html
+++ b/templates/admin/guest_badges.html
@@ -1,5 +1,15 @@
 <!-- templates/admin/guest_badges.html -->
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 
 {% block title %}Badge Management | Conference Management{% endblock %}
 

--- a/templates/admin/journey_management.html
+++ b/templates/admin/journey_management.html
@@ -1,5 +1,15 @@
 <!-- templates/admin/journey_management.html -->
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 
 {% block title %}Journey Management | Conference Management{% endblock %}
 

--- a/templates/admin/messages_management.html
+++ b/templates/admin/messages_management.html
@@ -1,4 +1,14 @@
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 {% block title %}Messages Management | Conference Management{% endblock %}
 
 {% block content %}

--- a/templates/admin/presentations_management.html
+++ b/templates/admin/presentations_management.html
@@ -1,4 +1,14 @@
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 {% block title %}Presentations Management | Conference Management{% endblock %}
 
 {% block content %}

--- a/templates/admin/report.html
+++ b/templates/admin/report.html
@@ -1,13 +1,35 @@
 <!-- templates/admin/report.html -->
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 
 {% block title %}Reports | Conference Management{% endblock %}
 
 {% block content %}
 <div class="row mb-4">
     <div class="col-12">
-        <h1 class="h3 mb-2">Conference Reports</h1>
-        <p class="text-muted">Generate and view comprehensive reports for the conference</p>
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="h3 mb-2">Conference Reports</h1>
+                <p class="text-muted">Generate and view comprehensive reports for the conference</p>
+            </div>
+            <div class="d-flex gap-2">
+                <a href="/admin/dashboard" class="btn btn-outline-secondary">
+                    <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+                </a>
+                <a href="/logout" class="btn btn-outline-secondary">
+                    <i class="fas fa-sign-out-alt me-1"></i> Logout
+                </a>
+            </div>
+        </div>
     </div>
 </div>
 
@@ -72,7 +94,6 @@
                                 <li><a class="dropdown-item" href="/admin/report/export/guest_list?format=csv">Export Guest List (CSV)</a></li>
                                 <li><a class="dropdown-item" href="/admin/report/export/guest_list?format=excel">Export Guest List (Excel)</a></li>
                                 <li><a class="dropdown-item" href="/admin/report/export/attendance">Export Attendance</a></li>
-                                <li><a class="dropdown-item" href="/admin/report/export/payments">Export Payments</a></li>
                                 <li><a class="dropdown-item" href="/admin/report/export/journeys">Export Journey Data</a></li>
                             </ul>
                         </div>
@@ -187,22 +208,6 @@
 
 <!-- More Charts -->
 <div class="row mb-4">
-    <div class="col-md-6 mb-4">
-        <div class="card shadow-sm border-0 h-100">
-            <div class="card-header bg-white">
-                <h5 class="mb-0">Payment Status</h5>
-            </div>
-            <div class="card-body">
-                <canvas id="paymentStatusChart"></canvas>
-            </div>
-            <div class="card-footer bg-white">
-                <div class="d-flex justify-content-between align-items-center">
-                    <span class="text-muted">Total Collected:</span>
-                    <span class="fw-bold">₹{{ total_collected|round|int }}</span>
-                </div>
-            </div>
-        </div>
-    </div>
     
     <div class="col-md-6 mb-4">
         <div class="card shadow-sm border-0 h-100">
@@ -374,41 +379,6 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
     
-    // Payment Status Chart
-    const paymentCtx = document.getElementById('paymentStatusChart');
-    if (paymentCtx) {
-        const labels = {{ payment_status_labels|tojson }};
-        const values = {{ payment_status_values|tojson }};
-        
-        new Chart(paymentCtx, {
-            type: 'bar',
-            data: {
-                labels: labels,
-                datasets: [{
-                    label: 'Number of Guests',
-                    data: values,
-                    backgroundColor: '#1a237e'
-                }]
-            },
-            options: {
-                responsive: true,
-                plugins: {
-                    legend: {
-                        display: false
-                    },
-                    title: {
-                        display: false,
-                        text: 'Payment Status'
-                    }
-                },
-                scales: {
-                    y: {
-                        beginAtZero: true
-                    }
-                }
-            }
-        });
-    }
     
     // Presentation Types Chart
     const presentationTypesCtx = document.getElementById('presentationTypesChart');

--- a/templates/admin/reports/changelog_report.html
+++ b/templates/admin/reports/changelog_report.html
@@ -1,5 +1,15 @@
 <!-- templates/admin/reports/changelog_report.html -->
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 
 {% block title %}Changelog | Conference Management{% endblock %}
 

--- a/templates/admin/reports/faculty_report.html
+++ b/templates/admin/reports/faculty_report.html
@@ -1,5 +1,15 @@
 <!-- templates/admin/reports/faculty_report.html -->
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 
 {% block title %}Faculty Report | Conference Management{% endblock %}
 

--- a/templates/admin/reports/guest_report.html
+++ b/templates/admin/reports/guest_report.html
@@ -1,5 +1,15 @@
 <!-- templates/admin/reports/guest_report.html -->
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 
 {% block title %}Guest Report | Conference Management{% endblock %}
 
@@ -44,17 +54,6 @@
                         </select>
                     </div>
                     
-                    <div class="col-md-4">
-                        <label for="payment" class="form-label">Filter by Payment</label>
-                        <select class="form-select" id="payment" name="payment">
-                            <option value="">All Payment Statuses</option>
-                            {% for status in payment_statuses %}
-                            <option value="{{ status }}" {% if status == selected_payment %}selected{% endif %}>
-                                {{ status }}
-                            </option>
-                            {% endfor %}
-                        </select>
-                    </div>
                     
                     <div class="col-12 text-end">
                         <button type="submit" class="btn btn-primary">
@@ -77,10 +76,10 @@
             <div class="card-header bg-white d-flex justify-content-between align-items-center">
                 <h5 class="mb-0">Guest List</h5>
                 <div class="btn-group">
-                    <a href="/admin/report/export/guest_list?format=csv{% if selected_role %}&role={{ selected_role }}{% endif %}{% if selected_attendance %}&attendance={{ selected_attendance }}{% endif %}{% if selected_payment %}&payment={{ selected_payment }}{% endif %}" class="btn btn-sm btn-outline-success">
+                    <a href="/admin/report/export/guest_list?format=csv{% if selected_role %}&role={{ selected_role }}{% endif %}{% if selected_attendance %}&attendance={{ selected_attendance }}{% endif %}" class="btn btn-sm btn-outline-success">
                         <i class="fas fa-file-csv me-1"></i> Export CSV
                     </a>
-                    <a href="/admin/report/export/guest_list?format=excel{% if selected_role %}&role={{ selected_role }}{% endif %}{% if selected_attendance %}&attendance={{ selected_attendance }}{% endif %}{% if selected_payment %}&payment={{ selected_payment }}{% endif %}" class="btn btn-sm btn-outline-success">
+                    <a href="/admin/report/export/guest_list?format=excel{% if selected_role %}&role={{ selected_role }}{% endif %}{% if selected_attendance %}&attendance={{ selected_attendance }}{% endif %}" class="btn btn-sm btn-outline-success">
                         <i class="fas fa-file-excel me-1"></i> Export Excel
                     </a>
                 </div>
@@ -96,7 +95,6 @@
                                 <th>Contact</th>
                                 <th>Registration Date</th>
                                 <th>Attendance</th>
-                                <th>Payment</th>
                                 <th>Actions</th>
                             </tr>
                         </thead>
@@ -117,14 +115,6 @@
                                     <span class="badge {% if guest.DailyAttendance == 'True' %}bg-success{% else %}bg-secondary{% endif %}">
                                         {% if guest.DailyAttendance == 'True' %}Present{% else %}Absent{% endif %}
                                     </span>
-                                </td>
-                                <td>
-                                    <span class="badge {% if guest.PaymentStatus == 'Paid' %}bg-success{% elif guest.PaymentStatus == 'Pending' %}bg-warning{% else %}bg-danger{% endif %}">
-                                        {{ guest.PaymentStatus }}
-                                    </span>
-                                    {% if guest.PaymentStatus == 'Paid' %}
-                                    <small class="d-block">₹{{ guest.PaymentAmount }}</small>
-                                    {% endif %}
                                 </td>
                                 <td>
                                     <a href="/single_guest/{{ guest.ID }}" class="btn btn-sm btn-outline-primary">

--- a/templates/admin/reports/journeys_report.html
+++ b/templates/admin/reports/journeys_report.html
@@ -1,5 +1,15 @@
 <!-- templates/admin/reports/journeys_report.html -->
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 
 {% block title %}Travel Report | Conference Management{% endblock %}
 

--- a/templates/admin/reports/presentations_report.html
+++ b/templates/admin/reports/presentations_report.html
@@ -1,5 +1,15 @@
 <!-- templates/admin/reports/presentations_report.html -->
 {% extends "base.html" %}
+{% block admin_nav %}
+<div class="navbar-nav ms-auto">
+    <a href="/admin/dashboard" class="nav-link">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="nav-link">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+</div>
+{% endblock %}
 
 {% block title %}Presentations Report | Conference Management{% endblock %}
 

--- a/templates/admin/single_guest.html
+++ b/templates/admin/single_guest.html
@@ -563,12 +563,6 @@
                                     </div>
                                     {% endif %}
                                     
-                                    {% if guest.PaymentAmount %}
-                                    <div class="mb-3">
-                                        <label class="form-label fw-bold text-muted">Payment Amount</label>
-                                        <div class="editable-field">₹{{ guest.PaymentAmount }}</div>
-                                    </div>
-                                    {% endif %}
                                     
                                     {% if guest.CompanyName %}
                                     <div class="mb-3">
@@ -1266,37 +1260,7 @@
                             </div>
                         </div>
 
-                        <!-- Payment Status -->
-                        <h6 class="mb-3">Payment Information</h6>
-                        <div class="row g-3 mb-4">
-                            <div class="col-md-4">
-                                <div class="status-card {% if guest.PaymentStatus == 'Paid' %}active{% else %}inactive{% endif %}">
-                                    <div class="mb-2">
-                                        <i class="fas fa-money-bill-wave fa-2x {% if guest.PaymentStatus == 'Paid' %}text-success{% else %}text-muted{% endif %}"></i>
-                                    </div>
-                                    <div class="fw-bold">Payment Status</div>
-                                    <span class="status-badge {% if guest.PaymentStatus == 'Paid' %}true{% else %}false{% endif %}">
-                                        {{ guest.PaymentStatus or 'Pending' }}
-                                    </span>
-                                    {% if guest.PaymentAmount and guest.PaymentAmount != '0' %}
-                                    <small class="d-block text-muted mt-1">₹{{ guest.PaymentAmount }}</small>
-                                    {% endif %}
-                                </div>
-                            </div>
 
-                            <div class="col-md-4">
-                                <div class="status-card {% if guest.PaymentMethod %}active{% else %}inactive{% endif %}">
-                                    <div class="mb-2">
-                                        <i class="fas fa-credit-card fa-2x {% if guest.PaymentMethod %}text-info{% else %}text-muted{% endif %}"></i>
-                                    </div>
-                                    <div class="fw-bold">Payment Method</div>
-                                    <span class="badge bg-info">{{ guest.PaymentMethod or 'Not specified' }}</span>
-                                    {% if guest.PaymentDate %}
-                                    <small class="d-block text-muted mt-1">{{ guest.PaymentDate }}</small>
-                                    {% endif %}
-                                </div>
-                            </div>
-                        </div>
 
                         <!-- Food Status -->
                         <h6 class="mb-3">Food & Meals</h6>
@@ -1386,11 +1350,6 @@
                                     </button>
                                 </div>
                                 <div class="col-md-3">
-                                    <button class="btn btn-outline-success btn-sm w-100" onclick="updatePaymentStatus()">
-                                        <i class="fas fa-money-bill-wave me-1"></i>Update Payment
-                                    </button>
-                                </div>
-                                <div class="col-md-3">
                                     <button class="btn btn-outline-secondary btn-sm w-100" onclick="refreshStatus()">
                                         <i class="fas fa-sync-alt me-1"></i>Refresh Status
                                     </button>
@@ -1454,22 +1413,6 @@
                             </button>
                         </div>
                         
-                        {% if guest.GuestRole == 'Delegates' %}
-                        <!-- Payment Actions -->
-                        <div class="quick-action-card">
-                            <h6 class="fw-bold text-primary mb-2">
-                                <i class="fas fa-money-bill-wave me-1"></i>
-                                Payment
-                            </h6>
-                            
-                            <button class="btn btn-outline-success btn-sm w-100" 
-                                    onclick="showPaymentModal('{{ guest.ID }}')"
-                                    {% if guest.PaymentReceived == 'True' %}disabled{% endif %}>
-                                <i class="fas fa-money-bill-wave me-2"></i>
-                                {% if guest.PaymentReceived == 'True' %}Payment Received{% else %}Record Payment{% endif %}
-                            </button>
-                        </div>
-                        {% endif %}
                     </div>
                 </div>
                 
@@ -1492,42 +1435,6 @@
         </div>
     </div>
 
-    <!-- Payment Modal -->
-    <div class="modal fade" id="paymentModal" tabindex="-1" aria-labelledby="paymentModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="paymentModalLabel">Record Payment</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <form id="paymentForm">
-                        <div class="mb-3">
-                            <label for="paymentAmount" class="form-label">Payment Amount (₹)</label>
-                            <input type="number" class="form-control" id="paymentAmount" step="0.01" min="0" required>
-                        </div>
-                        <div class="mb-3">
-                            <label for="paymentMethod" class="form-label">Payment Method</label>
-                            <select class="form-select" id="paymentMethod">
-                                <option value="cash">Cash</option>
-                                <option value="card">Card</option>
-                                <option value="upi">UPI</option>
-                                <option value="bank_transfer">Bank Transfer</option>
-                            </select>
-                        </div>
-                        <div class="mb-3">
-                            <label for="paymentNotes" class="form-label">Notes (Optional)</label>
-                            <textarea class="form-control" id="paymentNotes" rows="2"></textarea>
-                        </div>
-                    </form>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                    <button type="button" class="btn btn-primary" onclick="processPayment()">Record Payment</button>
-                </div>
-            </div>
-        </div>
-    </div>
 
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
@@ -2057,51 +1964,6 @@
             }
         }
         
-        // Payment Functions
-        function showPaymentModal(guestId) {
-            currentGuestId = guestId;
-            const modal = new bootstrap.Modal(document.getElementById('paymentModal'));
-            modal.show();
-        }
-        
-        function processPayment() {
-            const amount = document.getElementById('paymentAmount').value;
-            const method = document.getElementById('paymentMethod').value;
-            const notes = document.getElementById('paymentNotes').value;
-            
-            if (!amount || parseFloat(amount) <= 0) {
-                showNotification('Please enter a valid payment amount', 'error');
-                return;
-            }
-            
-            fetch('/admin/update-payment', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({ 
-                    guestId: currentGuestId,
-                    amount: parseFloat(amount),
-                    method: method,
-                    notes: notes
-                })
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (data.success) {
-                    showNotification(data.message || 'Payment recorded successfully', 'success');
-                    bootstrap.Modal.getInstance(document.getElementById('paymentModal')).hide();
-                    setTimeout(() => location.reload(), 1500);
-                } else {
-                    showNotification(data.message || 'An error occurred', 'error');
-                }
-            })
-            .catch(error => {
-                console.error('Error:', error);
-                showNotification('An unexpected error occurred', 'error');
-            });
-        }
-
         // Status Tab Functions
         function toggleAttendance() {
             fetch('/admin/toggle_attendance', {
@@ -2221,10 +2083,6 @@
                 'food_day2': 'Not Given'
             };
             return inactiveTexts[status] || 'Inactive';
-        }
-
-        function updatePaymentStatus() {
-            showPaymentModal(currentGuestId);
         }
 
         let statusInterval;

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,8 @@
     </header>
 
     <!-- Navigation -->
-    {% include 'components/navbar.html' %}
+{% include 'components/navbar.html' %}
+{% block admin_nav %}{% endblock %}
 
     <!-- Main Content -->
     <main class="container py-4 flex-grow-1">


### PR DESCRIPTION
## Summary
- add `admin_nav` block in `base.html`
- include dashboard/logout links on every admin template
- add logout link in all_guests header
- remove payment references from admin templates
- provide `/admin/logout` backend route

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6859860165d0832c8fff00a7b9dfa717