### PR TITLE
Fix main.js module loading

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -42,7 +42,7 @@
     <!-- Chart.js for data visualization -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <!-- Custom JS -->
-    <script src="/static/js/main.js"></script>
+    <script type="module" src="/static/js/main.js"></script>
     {% block extra_js %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load main.js as an ES module so imports work

## Testing
- `python -m py_compile $(find . -name '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859939957e8832cbefb90adac16c96f