### PR TITLE
Remove 'Guest' option from guest role dropdown

### DIFF
--- a/templates/guest_registration.html
+++ b/templates/guest_registration.html
@@ -143,7 +143,6 @@
                                 <option value="Faculty">Faculty</option>
                                 <option value="Sponsor">Sponsor</option>
                                 <option value="Staff">Staff</option>
-                                <option value="Guest">Guest</option>
                             </select>
                             <div class="invalid-feedback">
                                 Please select a role


### PR DESCRIPTION
## Summary
- remove obsolete Guest option from the role selector on the guest registration form

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cee2007a8832ca82837400e419f07