### PR TITLE
Add KMC number field support

### DIFF
--- a/app/models/guest.py
+++ b/app/models/guest.py
@@ -42,6 +42,7 @@ class Guest:
         self.payment_date = ""
         self.payment_method = ""
         self.organization = ""
+        self.kmc_number = ""
         self.notes = ""
         # New fields
         self.journey_details_updated = "False"
@@ -65,9 +66,11 @@ class Guest:
             # Convert to standard object attribute names (camelCase to snake_case)
             attr_name = key[0].lower() + key[1:]
             
-            # Special case for ID
+            # Special cases for fields that don't map directly
             if key == "ID":
                 attr_name = "id"
+            elif key == "KMCNumber":
+                attr_name = "kmc_number"
             
             # Check if attribute exists and set value
             if hasattr(instance, attr_name):
@@ -98,6 +101,7 @@ class Guest:
             "PaymentDate": self.payment_date,
             "PaymentMethod": self.payment_method,
             "Organization": self.organization,
+            "KMCNumber": self.kmc_number,
             "Notes": self.notes,
             "JourneyDetailsUpdated": self.journey_details_updated,
             "JourneyCompleted": self.journey_completed,
@@ -126,5 +130,8 @@ class Guest:
             
         if self.guest_role not in ["Delegate", "Faculty", "Staff", "Sponsor", "Guest"]:
             errors.append("Invalid guest role")
-            
+
+        if self.kmc_number and not self.kmc_number.isdigit():
+            errors.append("KMC number must be numeric")
+
         return errors

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -482,7 +482,7 @@ def reset_main_database():
             "InwardJourneyTo", "InwardJourneyDetails", "InwardPickupRequired",
             "InwardJourneyRemarks", "OutwardJourneyDate", "OutwardJourneyFrom",
             "OutwardJourneyTo", "OutwardJourneyDetails", "OutwardDropRequired",
-            "OutwardJourneyRemarks", "Organization", "Batch", "CompanyName"
+            "OutwardJourneyRemarks", "Organization", "KMCNumber", "Batch", "CompanyName"
         ]
 
         csv_path = config.get('DATABASE', 'CSVPath')
@@ -3603,6 +3603,9 @@ def ensure_all_guest_fields():
             "BadgeGivenDate": "",
             "KitReceivedDate": "",
             "CheckInTime": "",
+
+            # New KMC column
+            "KMCNumber": "",
 
             # Payment related fields
             "PaymentStatus": "Pending",


### PR DESCRIPTION
## Summary
- extend `Guest` model with `kmc_number`
- persist `KMCNumber` when reading/writing guests
- validate `kmc_number` if provided
- update admin CSV reset helpers to include `KMCNumber`
- ensure existing data gains `KMCNumber` column

## Testing
- `python -m py_compile app/models/guest.py app/routes/admin.py`

------
https://chatgpt.com/codex/tasks/task_e_685cf5a516b8832c8dfc1574f0a8d88a