### PR TITLE
Add KMC number editing

### DIFF
--- a/app/routes/guest.py
+++ b/app/routes/guest.py
@@ -559,7 +559,8 @@ async def update_profile(
     request: Request,
     guest: Dict = Depends(get_current_guest),
     email: str = Form(...),
-    phone: str = Form(...)
+    phone: str = Form(...),
+    kmc_number: str = Form("")
 ):
     """Update guest profile information"""
     try:
@@ -580,11 +581,12 @@ async def update_profile(
         # Update guest
         guests = guests_db.read_all()
         updated = False
-        
+
         for g in guests:
             if g["ID"] == guest["ID"]:
                 g["Email"] = email
                 g["Phone"] = phone
+                g["KMCNumber"] = kmc_number
                 updated = True
                 break
         

--- a/templates/guest/profile.html
+++ b/templates/guest/profile.html
@@ -213,6 +213,13 @@
                             <small class="text-end"><strong>{{ guest.Email or 'Not provided' }}</strong></small>
                         </div>
                     </div>
+
+                    <div class="info-row">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <small class="text-muted"><i class="fas fa-id-badge me-1"></i>KMC No:</small>
+                            <strong>{{ guest.KMCNumber or 'N/A' }}</strong>
+                        </div>
+                    </div>
                     
                     <div class="info-row">
                         <div class="d-flex justify-content-between">
@@ -767,6 +774,10 @@
                         <label for="phone" class="form-label">Phone Number</label>
                         <input type="text" class="form-control" id="phone" name="phone" value="{{ guest.Phone }}">
                         <div class="form-text">10-digit phone number without spaces or hyphens</div>
+                    </div>
+                    <div class="compact-input">
+                        <label for="kmc_number" class="form-label">KMC Number</label>
+                        <input type="text" class="form-control" id="kmc_number" name="kmc_number" value="{{ guest.KMCNumber or '' }}">
                     </div>
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
## Summary
- show guest KMC number in profile details
- allow editing KMC number in profile modal
- store kmc_number in update_profile route

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cfa9ee6d8832cb8854e02427f4151