### PR TITLE
Add KMC number handling for faculty profile

### DIFF
--- a/app/models/faculty.py
+++ b/app/models/faculty.py
@@ -33,6 +33,7 @@ class FacultyProfile(BaseModel):
     name: str
     email: EmailStr
     phone: str
+    kmc_number: Optional[str] = None
     photo_path: Optional[str] = None
     roles: List[FacultyRole]
     kit_faculty: bool = False

--- a/app/routes/faculty.py
+++ b/app/routes/faculty.py
@@ -65,7 +65,11 @@ async def get_current_faculty(token: str = Depends(oauth2_scheme)) -> FacultyPro
     faculty = next((f for f in faculty_data if f["id"] == faculty_id), None)
     if faculty is None:
         raise credentials_exception
-    return FacultyProfile(**faculty)
+
+    faculty_info = faculty.copy()
+    faculty_info["kmc_number"] = faculty.get("KMCNumber") or faculty.get("kmc_number")
+
+    return FacultyProfile(**faculty_info)
 
 @router.get("/dashboard", response_class=HTMLResponse)
 async def faculty_dashboard(request: Request):
@@ -182,6 +186,7 @@ async def update_profile(
     request: Request,
     email: str = Form(...),
     phone: str = Form(...),
+    kmc_number: str = Form(""),
     photo: Optional[UploadFile] = File(None),
     current_faculty: FacultyProfile = Depends(get_current_faculty)
 ):
@@ -220,6 +225,7 @@ async def update_profile(
     faculty_data[faculty_idx].update({
         "email": email,
         "phone": phone,
+        "KMCNumber": kmc_number,
         "updated_at": datetime.now().isoformat()
     })
     

--- a/templates/faculty/profile.html
+++ b/templates/faculty/profile.html
@@ -44,6 +44,10 @@
                         <dd class="mt-1 text-sm text-gray-900">{{ faculty.phone }}</dd>
                     </div>
                     <div class="sm:col-span-1">
+                        <dt class="text-sm font-medium text-gray-500">KMC Number</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{ faculty.kmc_number or 'N/A' }}</dd>
+                    </div>
+                    <div class="sm:col-span-1">
                         <dt class="text-sm font-medium text-gray-500">Roles</dt>
                         <dd class="mt-1 text-sm text-gray-900">
                             {% for role in faculty.roles %}
@@ -278,6 +282,11 @@
                 <div class="mb-4">
                     <label for="phone" class="block text-sm font-medium text-gray-700">Phone</label>
                     <input type="tel" name="phone" id="phone" value="{{ faculty.phone }}"
+                        class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md">
+                </div>
+                <div class="mb-4">
+                    <label for="kmc_number" class="block text-sm font-medium text-gray-700">KMC Number</label>
+                    <input type="text" name="kmc_number" id="kmc_number" value="{{ faculty.kmc_number or '' }}"
                         class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md">
                 </div>
                 <div class="mb-4">


### PR DESCRIPTION
## Summary
- display faculty KMC number on profile page
- allow editing KMC number in the edit modal
- expose kmc_number from faculty data
- persist kmc_number when updating profile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cfcd9c18c832ca13ceeaec6f58a5f