### PR TITLE
Add KMC number support across admin views

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -860,7 +860,7 @@ async def export_guest_list(
             
             # Write header
             writer.writerow([
-                "ID", "Name", "Email", "Phone", "Role", "Registration Date", 
+                "ID", "Name", "Email", "Phone", "KMC Number", "Role", "Registration Date",
                 "Check-in Status", "Kit Status", "Badge Status", "Payment Status", "Amount"
             ])
             
@@ -871,6 +871,7 @@ async def export_guest_list(
                     guest.get("Name", ""),
                     guest.get("Email", ""),
                     guest.get("Phone", ""),
+                    guest.get("KMCNumber", ""),
                     guest.get("GuestRole", ""),
                     guest.get("RegistrationDate", ""),
                     "Checked In" if guest.get("DailyAttendance") == "True" else "Not Checked In",
@@ -903,6 +904,7 @@ async def export_guest_list(
                         "Name": guest.get("Name", ""),
                         "Email": guest.get("Email", ""),
                         "Phone": guest.get("Phone", ""),
+                        "KMC Number": guest.get("KMCNumber", ""),
                         "Role": guest.get("GuestRole", ""),
                         "Registration Date": guest.get("RegistrationDate", ""),
                         "Check-in Status": "Checked In" if guest.get("DailyAttendance") == "True" else "Not Checked In",
@@ -2730,6 +2732,7 @@ async def update_guest_basic_info(request: Request, admin: Dict = Depends(get_cu
         name = data.get('name')
         email = data.get('email')
         phone = data.get('phone')
+        kmc_number = data.get('kmc_number')
         
         guests = guests_db.read_all()
         updated = False
@@ -2739,6 +2742,7 @@ async def update_guest_basic_info(request: Request, admin: Dict = Depends(get_cu
                 guest["Name"] = name
                 guest["Email"] = email
                 guest["Phone"] = phone
+                guest["KMCNumber"] = kmc_number
                 updated = True
                 break
                 
@@ -2994,6 +2998,10 @@ def create_magnacode_badge(guest: dict) -> Image.Image:
     draw.text((info_x + info_width//2, role_y + role_height//2), role.upper(), fill='white', anchor="mm", font_size=22)
 
     contact_y = role_y + role_height + 30
+    kmc = guest.get('KMCNumber', '')
+    if kmc:
+        draw.text((info_x + 15, contact_y), f"KMC: {kmc}", fill=charcoal, font_size=16)
+        contact_y += 40
     phone = guest.get('Phone', '')
     if phone:
         if len(phone) == 10 and phone.isdigit():
@@ -3175,6 +3183,13 @@ def create_magnacode_badge_working(guest: dict) -> Image.Image:
         draw.text((info_x + info_width//2, role_y + role_height//2), role.upper(), fill='white', anchor="mm")
 
     contact_y = role_y + role_height + 30
+    kmc = guest.get('KMCNumber', '')
+    if kmc:
+        try:
+            draw.text((info_x + 15, contact_y), f"KMC: {kmc}", fill=charcoal, font_size=16)
+        except TypeError:
+            draw.text((info_x + 15, contact_y), f"KMC: {kmc}", fill=charcoal)
+        contact_y += 40
     phone = guest.get('Phone', '')
     if phone:
         if len(phone) == 10 and phone.isdigit():

--- a/app/routes/common.py
+++ b/app/routes/common.py
@@ -1123,6 +1123,10 @@ def create_magnacode_badge(guest: dict) -> Image.Image:
     draw.text((info_x + info_width//2, role_y + role_height//2), role.upper(), fill='white', anchor="mm", font_size=22)
 
     contact_y = role_y + role_height + 30
+    kmc = guest.get('KMCNumber', '')
+    if kmc:
+        draw.text((info_x + 15, contact_y), f"KMC: {kmc}", fill=charcoal, font_size=16)
+        contact_y += 40
     phone = guest.get('Phone', '')
     if phone:
         if len(phone) == 10 and phone.isdigit():

--- a/templates/admin/all_guests.html
+++ b/templates/admin/all_guests.html
@@ -128,6 +128,7 @@
                                         <th>ID</th>
                                         <th>Name</th>
                                         <th>Role</th>
+                                        <th>KMC</th>
                                         <th>Phone</th>
                                         <th>Email</th>
                                         <th>Attendance</th>
@@ -143,6 +144,7 @@
                                         <td>
                                             <span class="badge bg-primary">{{ guest.GuestRole }}</span>
                                         </td>
+                                        <td>{{ guest.KMCNumber or 'N/A' }}</td>
                                         <td>{{ guest.Phone or 'Not provided' }}</td>
                                         <td>{{ guest.Email or 'Not provided' }}</td>
                                         <td>
@@ -180,7 +182,7 @@
                                     
                                     {% if not guests %}
                                     <tr>
-                                        <td colspan="8" class="text-center py-4">
+                                        <td colspan="9" class="text-center py-4">
                                             <p class="text-muted mb-0">No guests found matching the current filters</p>
                                         </td>
                                     </tr>

--- a/templates/admin/guest_badges.html
+++ b/templates/admin/guest_badges.html
@@ -88,6 +88,7 @@
                                 <th>ID</th>
                                 <th>Name</th>
                                 <th>Role</th>
+                                <th>KMC</th>
                                 <th>Badge Status</th>
                                 <th>Actions</th>
                             </tr>
@@ -103,6 +104,7 @@
                                 <td>{{ guest.ID }}</td>
                                 <td>{{ guest.Name }}</td>
                                 <td><span class="badge bg-primary">{{ guest.GuestRole }}</span></td>
+                                <td>{{ guest.KMCNumber or 'N/A' }}</td>
                                 <td>
                                     <div>
                                         <span class="badge {% if guest.BadgePrinted == 'True' %}bg-success{% else %}bg-warning{% endif %} me-1">
@@ -155,7 +157,7 @@
                             
                             {% if not guests %}
                             <tr>
-                                <td colspan="6" class="text-center py-4">
+                                <td colspan="7" class="text-center py-4">
                                     <p class="text-muted mb-0">No guests found matching the current filters</p>
                                 </td>
                             </tr>

--- a/templates/admin/single_guest.html
+++ b/templates/admin/single_guest.html
@@ -548,6 +548,10 @@
                                         <label class="form-label fw-bold text-muted">Phone</label>
                                         <div class="editable-field" id="displayPhone">{{ guest.Phone or 'Not provided' }}</div>
                                     </div>
+                                    <div class="mb-3">
+                                        <label class="form-label fw-bold text-muted">KMC Number</label>
+                                        <div class="editable-field" id="displayKMC">{{ guest.KMCNumber or 'Not provided' }}</div>
+                                    </div>
                                 </div>
                                 
                                 <div class="col-md-6">
@@ -594,6 +598,12 @@
                                         <div class="mb-3">
                                             <label class="form-label">Phone</label>
                                             <input type="tel" class="form-control" id="editPhone" value="{{ guest.Phone or '' }}">
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div class="mb-3">
+                                            <label class="form-label">KMC Number</label>
+                                            <input type="text" class="form-control" id="editKMCNumber" value="{{ guest.KMCNumber or '' }}">
                                         </div>
                                     </div>
                                 </div>
@@ -1659,6 +1669,7 @@
             const name = document.getElementById('editName').value;
             const email = document.getElementById('editEmail').value;
             const phone = document.getElementById('editPhone').value;
+            const kmcNumber = document.getElementById('editKMCNumber').value;
             
             showLoading('basicEdit');
             
@@ -1671,7 +1682,8 @@
                     guest_id: currentGuestId,
                     name: name,
                     email: email,
-                    phone: phone
+                    phone: phone,
+                    kmc_number: kmcNumber
                 })
             })
             .then(response => response.json())
@@ -1682,6 +1694,7 @@
                     document.getElementById('displayName').textContent = name || 'Not provided';
                     document.getElementById('displayEmail').textContent = email || 'Not provided';
                     document.getElementById('displayPhone').textContent = phone || 'Not provided';
+                    document.getElementById('displayKMC').textContent = kmcNumber || 'Not provided';
                     
                     showNotification(data.message || 'Basic information updated successfully', 'success');
                     toggleBasicEdit();

--- a/templates/check_in.html
+++ b/templates/check_in.html
@@ -72,6 +72,7 @@
                                     <p class="mb-0"><strong>ID:</strong> {{ guest.ID }}</p>
                                     <p class="mb-0"><strong>Phone:</strong> {{ guest.Phone }}</p>
                                     <p class="mb-0"><strong>Email:</strong> {{ guest.Email or 'Not provided' }}</p>
+                                    <p class="mb-0"><strong>KMC:</strong> {{ guest.KMCNumber or 'N/A' }}</p>
                                     
                                     <div class="mt-2">
                                         <span class="badge {% if guest.DailyAttendance == 'True' %}bg-success{% else %}bg-warning{% endif %} me-2">

--- a/templates/components/cards/guest_card.html
+++ b/templates/components/cards/guest_card.html
@@ -16,6 +16,7 @@
             <div class="col-md-6">
                 <p><strong>Phone:</strong> {{ guest.Phone }}</p>
                 <p><strong>Email:</strong> {{ guest.Email or 'Not provided' }}</p>
+                <p><strong>KMC:</strong> {{ guest.KMCNumber or 'N/A' }}</p>
                 <p>
                     <strong>Attendance:</strong> 
                     <span class="text-{% if guest.DailyAttendance == 'True' %}success{% else %}danger{% endif %}">


### PR DESCRIPTION
## Summary
- display KMC numbers in guest lists and badges
- allow editing KMC number in admin guest view
- include `kmc_number` when updating guests
- export KMC numbers in CSV/Excel reports
- show KMC number when creating badges

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cfe581464832ca894957671225488