### PR TITLE
Add KMC number display on guest views

### DIFF
--- a/app/routes/common.py
+++ b/app/routes/common.py
@@ -125,11 +125,14 @@ async def check_in_guest(request: Request, guest_id: str = Form(...)):
         # Log the check-in
         log_checkin(guest["ID"], guest.get("Name", ""), guest.get("GuestRole", ""))
 
+        kmc_number = guest.get("KMCNumber")
+
         return templates.TemplateResponse(
             "check_in.html",
             {
                 "request": request,
                 "guest": guest,
+                "kmc_number": kmc_number,
                 "recent_checkins": recent_checkins,
                 "active_page": "check_in"
             }

--- a/templates/single_guest.html
+++ b/templates/single_guest.html
@@ -453,7 +453,8 @@
                                         </p>
                                         <p class="text-muted mb-0">
                                             <i class="fas fa-envelope me-1"></i> {{ guest.Email or 'Not provided' }} |
-                                            <i class="fas fa-phone me-1"></i> {{ guest.Phone or 'Not provided' }}
+                                            <i class="fas fa-phone me-1"></i> {{ guest.Phone or 'Not provided' }} |
+                                            <strong>KMC:</strong> {{ guest.KMCNumber or 'N/A' }}
                                         </p>
                                     </div>
                                 </div>
@@ -537,6 +538,10 @@
                                     <div class="mb-3">
                                         <label class="form-label fw-bold text-muted">Phone</label>
                                         <div class="editable-field" id="displayPhone">{{ guest.Phone or 'Not provided' }}</div>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label fw-bold text-muted">KMC Number</label>
+                                        <div class="editable-field">{{ guest.KMCNumber or 'N/A' }}</div>
                                     </div>
                                 </div>
                                 


### PR DESCRIPTION
## Summary
- show KMC number in the general guest view template
- include KMC detail in the basic info section
- expose `kmc_number` when loading a guest for check‑in

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d158e93a8832cbd59608fa11ccdbe