### PR TITLE
Remove help overlay button

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -443,10 +443,6 @@
                 </h5>
                 
                 <div class="d-grid gap-3">
-                    <button class="btn info-btn d-flex align-items-center justify-content-between" onclick="toggleHelpOverlay()">
-                        <span><i class="fas fa-question-circle me-2"></i>How to Use This System</span>
-                        <i class="fas fa-external-link-alt"></i>
-                    </button>
 
                     <button class="btn info-btn d-flex align-items-center justify-content-between" onclick="showVenueInfo()">
                         <span><i class="fas fa-map-marker-alt me-2"></i>Venue Information</span>


### PR DESCRIPTION
## Summary
- remove "How to Use This System" button from Information & Help panel

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d19e63de0832c9da8531cd3fb7c01