### PR TITLE
Update organizer naming in UI

### DIFF
--- a/templates/admin/gift_management.html
+++ b/templates/admin/gift_management.html
@@ -616,10 +616,10 @@ function createGiftDetailsContent(guest) {
             'Committee Memento'
         ],
         'Staff': [
-            'Staff Appreciation Kit',
+            'Organizer Appreciation Kit',
             'MAGNACODE 2025 T-Shirt',
             'Certificate of Service',
-            'Staff Badge',
+            'Organizer Badge',
             'Conference Bag'
         ]
     };

--- a/templates/admin/single_guest.html
+++ b/templates/admin/single_guest.html
@@ -1617,10 +1617,10 @@
                     'Committee Memento'
                 ],
                 'Staff': [
-                    'Staff Appreciation Kit',
+                    'Organizer Appreciation Kit',
                     'MAGNACODE 2025 T-Shirt',
                     'Certificate of Service',
-                    'Staff Badge',
+                    'Organizer Badge',
                     'Conference Bag'
                 ]
             };

--- a/templates/components/help_system.html
+++ b/templates/components/help_system.html
@@ -56,7 +56,7 @@
     <ul>
         <li><strong>Delegates:</strong> Name, Phone, Email, Batch</li>
         <li><strong>Sponsors:</strong> Name, Phone, Company Name</li>
-        <li><strong>Staff/Event:</strong> Basic contact information</li>
+        <li><strong>Organizer/Event:</strong> Basic contact information</li>
     </ul>
     <p class="mt-3"><strong>Tip:</strong> Use the "Generate Dummy Registrations" feature in Admin to create multiple registration IDs at once.</p>
 </template>

--- a/templates/guest_registration.html
+++ b/templates/guest_registration.html
@@ -142,7 +142,7 @@
                                 <option value="Delegate">Delegate</option>
                                 <option value="Faculty">Faculty</option>
                                 <option value="Sponsor">Sponsor</option>
-                                <option value="Staff">Staff</option>
+                                <option value="Staff">Organizer</option>
                             </select>
                             <div class="invalid-feedback">
                                 Please select a role

--- a/templates/index.html
+++ b/templates/index.html
@@ -496,12 +496,12 @@
         <!-- Admin Access - Discrete Section -->
         <div class="admin-section">
             <div class="text-center">
-                <small class="text-muted fw-bold d-block mb-3">STAFF & ORGANIZERS</small>
+                <small class="text-muted fw-bold d-block mb-3">ORGANIZERS & COMMITTEE</small>
                 <a href="/admin_dashboard" class="btn admin-btn">
                     <i class="fas fa-cogs me-2"></i>
                     <small>Administrative Panel</small>
                 </a>
-                <p class="small text-muted mt-2 mb-0">For conference staff and organizers only</p>
+                <p class="small text-muted mt-2 mb-0">For conference organizers and committee only</p>
             </div>
         </div>
     </div>

--- a/templates/single_guest.html
+++ b/templates/single_guest.html
@@ -1547,10 +1547,10 @@
                     'Committee Memento'
                 ],
                 'Staff': [
-                    'Staff Appreciation Kit',
+                    'Organizer Appreciation Kit',
                     'MAGNACODE 2025 T-Shirt',
                     'Certificate of Service',
-                    'Staff Badge',
+                    'Organizer Badge',
                     'Conference Bag'
                 ]
             };


### PR DESCRIPTION
## Summary
- update admin section text to "ORGANIZERS & COMMITTEE"
- rename staff dropdown label to "Organizer"
- tweak help system role description
- update staff gift names for single guest and gift management pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d21a8c3cc832cbf10706021eff28c