### PR TITLE
Add guest phone to presentations management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Fix admin journey update deleting records due to mismatched CSV columns.
   Admin updates now use normalized field names to prevent CSV corruption.
+- Display guest phone numbers on the Presentations Management page for easier contact.

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1554,6 +1554,7 @@ async def presentations_management(request: Request, admin: Dict = Depends(get_c
             if g:
                 p['guest_name'] = g.get('Name', 'Unknown')
                 p['guest_role'] = g.get('GuestRole', '')
+                p['guest_phone'] = g.get('Phone', '')
             p['file_url'] = f"/admin/download_presentation/{p.get('file_path')}"
 
         return templates.TemplateResponse(

--- a/templates/admin/presentations_management.html
+++ b/templates/admin/presentations_management.html
@@ -28,6 +28,7 @@
                 <thead class="table-light">
                     <tr>
                         <th>Guest</th>
+                        <th>Phone</th>
                         <th>Role</th>
                         <th>Title</th>
                         <th>Uploaded</th>
@@ -38,13 +39,14 @@
                 {% for p in presentations %}
                     <tr>
                         <td>{{ p.guest_name }} ({{ p.guest_id }})</td>
+                        <td>{{ p.guest_phone or 'Not provided' }}</td>
                         <td>{{ p.guest_role }}</td>
                         <td>{{ p.title }}</td>
                         <td>{{ p.upload_date }}</td>
                         <td><a href="{{ p.file_url }}" class="btn btn-sm btn-primary"><i class="fas fa-download me-1"></i>Download</a></td>
                     </tr>
                 {% else %}
-                    <tr><td colspan="5" class="text-center">No presentations found.</td></tr>
+                    <tr><td colspan="6" class="text-center">No presentations found.</td></tr>
                 {% endfor %}
                 </tbody>
             </table>


### PR DESCRIPTION
## Summary
- show guest phone numbers in the presentations management table
- provide phone in admin route when building presentation list
- update changelog

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686500c47f4c832c9b9fb94eed320aa7