### PR TITLE
Fix check-in error when photo URL field present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@ All notable changes to this project will be documented in this file.
 - Fix admin journey update deleting records due to mismatched CSV columns.
   Admin updates now use normalized field names to prevent CSV corruption.
 - Display guest phone numbers on the Presentations Management page for easier contact.
+- Fix check-in failures caused by temporary `photo_url` field being saved to the CSV database during guest lookup.


### PR DESCRIPTION
## Summary
- avoid persisting `photo_url` to csv when marking attendance
- note fix in changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68650e4d2b38832c8209a5011510223d