### PR TITLE
Fix admin message display collisions

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1812,14 +1812,14 @@ async def single_guest_view(request: Request, admin: Dict = Depends(get_current_
 
         # Get guest messages
         messages_csv = os.path.join(os.path.dirname(config.get('DATABASE', 'CSVPath')), 'messages.csv')
-        messages = []
+        guest_messages = []
         if os.path.exists(messages_csv):
             with open(messages_csv, 'r', newline='', encoding='utf-8') as f:
                 reader = csv.DictReader(f)
                 for row in reader:
                     if row.get('guest_id') == guest_id:
                         row['message'] = row.get('message') or row.get('content', '')
-                        messages.append(row)
+                        guest_messages.append(row)
 
         # Get guest activities (placeholder for now)
         activities = []
@@ -1832,7 +1832,7 @@ async def single_guest_view(request: Request, admin: Dict = Depends(get_current_
                 "guest": guest,
                 "guest_activities": activities,
                 "presentations": presentations,
-                "messages": messages,
+                "guest_messages": guest_messages,
                 "active_page": "all_guests"
             }
         )
@@ -2775,7 +2775,7 @@ async def messages_management(request: Request, q: str = ""):
     logging.info(f"[{trace_id}] Admin accessed messages_management with search='{q}'")
     messages_path = config.get('DATABASE', 'MessagesCSV', fallback='./data/messages.csv')
     guests_path = config.get('DATABASE', 'CSVPath', fallback='./data/guests.csv')
-    messages = []
+    guest_messages = []
     guests_map = {}
     guests_list = []
 
@@ -2800,7 +2800,7 @@ async def messages_management(request: Request, q: str = ""):
                 ):
                     continue
                 message_text = msg.get('message') or msg.get('content', '')
-                messages.append({
+                guest_messages.append({
                     "id": msg.get('id'),
                     "guest_id": msg['guest_id'],
                     "name": guest.get('Name', 'Unknown'),
@@ -2814,12 +2814,12 @@ async def messages_management(request: Request, q: str = ""):
     except Exception as e:
         logging.error(f"[{trace_id}] Failed reading messages: {e}")
 
-    logging.info(f"[{trace_id}] Loaded {len(messages)} messages for admin display.")
+    logging.info(f"[{trace_id}] Loaded {len(guest_messages)} messages for admin display.")
     return templates.TemplateResponse(
         "admin/messages_management.html",
         {
             "request": request,
-            "messages": messages,
+            "guest_messages": guest_messages,
             "search_query": q,
             "trace_id": trace_id,
             "guests": guests_list,

--- a/app/routes/guest.py
+++ b/app/routes/guest.py
@@ -256,13 +256,13 @@ async def profile_page(request: Request, guest: Dict = Depends(get_current_guest
                         presentations.append(row)
 
         # Get messages
-        messages = []
+        guest_messages = []
         if os.path.exists(MESSAGES_CSV):
             with open(MESSAGES_CSV, mode='r', newline='', encoding='utf-8') as file:
                 reader = csv.DictReader(file)
                 for row in reader:
                     if row.get("guest_id") == guest["ID"]:
-                        messages.append(row)
+                        guest_messages.append(row)
         
         # *** UPDATED: Get journey details using synchronized service ***
         journey_service = create_journey_service(config)
@@ -298,7 +298,7 @@ async def profile_page(request: Request, guest: Dict = Depends(get_current_guest
                 "request": request,
                 "guest": guest,
                 "presentations": presentations,
-                "messages": messages,
+                "guest_messages": guest_messages,
                 "inward_journey": inward_journey,
                 "outward_journey": outward_journey,
                 "user_role": "faculty" if guest["is_faculty"] else "guest",

--- a/templates/admin/messages_management.html
+++ b/templates/admin/messages_management.html
@@ -58,7 +58,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                {% for msg in messages %}
+                {% for msg in guest_messages %}
                     <tr>
                         <td>{{ msg.timestamp }}</td>
                         <td>{{ msg.guest_id }}</td>

--- a/templates/admin/single_guest.html
+++ b/templates/admin/single_guest.html
@@ -1189,7 +1189,7 @@
                                 </tr>
                                 </thead>
                                 <tbody>
-                                {% for m in messages %}
+                                {% for m in guest_messages %}
                                 <tr>
                                     <td>{{ m.timestamp }}</td>
                                     <td>{{ m.message }}</td>

--- a/templates/guest/profile.html
+++ b/templates/guest/profile.html
@@ -717,8 +717,8 @@
                             
                             <h6 class="mb-3">Message History</h6>
                             <div id="messageHistory" style="max-height: 400px; overflow-y: auto;">
-                                {% if messages %}
-                                    {% for msg in messages %}
+                                {% if guest_messages %}
+                                    {% for msg in guest_messages %}
                                     <div class="message-bubble">
                                         <div class="d-flex justify-content-between align-items-start mb-2">
                                             <small class="text-muted">


### PR DESCRIPTION
## Summary
- rename message list variables passed to templates
- update templates to iterate over `guest_messages`

## Testing
- `python -m py_compile app/routes/admin.py app/routes/guest.py`

------
https://chatgpt.com/codex/tasks/task_e_686526c25f9c832c9b63b29bf6ef5942