### PR TITLE
Fix missing header and padding on All Guests page

### DIFF
--- a/templates/admin/all_guests.html
+++ b/templates/admin/all_guests.html
@@ -1,19 +1,26 @@
 <!-- templates/admin/all_guests.html -->
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>All Guests | Conference Management</title>
-    
-    <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <!-- Font Awesome -->
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <!-- DataTables CSS -->
-    <link href="https://cdn.datatables.net/1.13.4/css/dataTables.bootstrap5.min.css" rel="stylesheet">
-    
-    <style>
+{% extends "base.html" %}
+{% block admin_nav %}
+<div class="btn-group ms-3" role="group">
+    <a href="/admin/dashboard" class="btn btn-primary btn-sm text-white">
+        <i class="fas fa-tachometer-alt me-1"></i> Dashboard
+    </a>
+    <a href="/logout" class="btn btn-danger btn-sm text-white">
+        <i class="fas fa-sign-out-alt me-1"></i> Logout
+    </a>
+    <a href="/admin/guest_badges" class="btn btn-secondary btn-sm text-white">
+        <i class="fas fa-id-badge me-1"></i> Badge Management
+    </a>
+</div>
+{% endblock %}
+
+{% block title %}All Guests | Conference Management{% endblock %}
+
+{% block extra_css %}
+<!-- DataTables CSS -->
+<link href="https://cdn.datatables.net/1.13.4/css/dataTables.bootstrap5.min.css" rel="stylesheet">
+
+<style>
         .bg-primary { background-color: #1a237e !important; }
         .text-primary { color: #1a237e !important; }
         .btn-primary { background-color: #1a237e; border-color: #1a237e; }
@@ -35,9 +42,9 @@
             border: none;
         }
     </style>
-</head>
-<body class="bg-light">
-    <div class="container-fluid py-4">
+{% endblock %}
+
+{% block content %}
         <!-- Header -->
         <div class="row mb-4">
             <div class="col-12">
@@ -195,15 +202,16 @@
             </div>
         </div>
     </div>
+{% endblock %}
 
-    <!-- Bootstrap JS -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <!-- DataTables JS -->
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
-    <script src="https://cdn.datatables.net/1.13.4/js/dataTables.bootstrap5.min.js"></script>
-    
-    <script>
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<!-- DataTables JS -->
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.4/js/dataTables.bootstrap5.min.js"></script>
+
+<script>
         // Initialize DataTable
         $(document).ready(function() {
             $('#guestsTable').DataTable({
@@ -310,6 +318,5 @@
                 }
             }, 5000);
         }
-    </script>
-</body>
-</html>
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- extend `base.html` in `all_guests.html`
- use admin navigation block for dashboard/logout/badges buttons
- rely on base layout padding and move scripts into `extra_js`

## Testing
- `pytest` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686528ef3f08832c82c4bdfaba40f2c3