### PR TITLE
Improve email sending reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,5 @@ All notable changes to this project will be documented in this file.
 - Fix check-in failures caused by temporary `photo_url` field being saved to the CSV database during guest lookup.
 - Send a confirmation email after successful guest registration using the
   configured SMTP settings.
+- Improve email reliability by falling back to STARTTLS when the initial
+  SSL connection is refused.

--- a/docs/2025-07-03-email-fallback.md
+++ b/docs/2025-07-03-email-fallback.md
@@ -1,0 +1,14 @@
+## Email fallback update
+
+- **Date:** 2025-07-03
+- **Author:** codex
+
+### Summary
+Implemented a fallback mechanism in `EmailService.send_email` to attempt STARTTLS when an SSL connection is refused. This improves reliability when the SMTP server does not accept SSL connections on the configured port.
+
+### Files Affected
+- `app/services/email_service.py`
+- `CHANGELOG.md`
+
+### Rationale
+Server logs showed `Connection refused` errors when sending emails via `SMTP_SSL`. Adding a STARTTLS fallback ensures that registration emails are still delivered if the server only supports TLS.


### PR DESCRIPTION
## Summary
- add STARTTLS fallback logic in `EmailService`
- document change in changelog
- create change document for the new email logic

## Testing
- `python -m py_compile app/services/email_service.py`


------
https://chatgpt.com/codex/tasks/task_e_6866580374dc832c8a2257127b933a61