### PR TITLE
Remove profile link in welcome email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,5 @@ All notable changes to this project will be documented in this file.
 - Switch default SMTP port to 587 with STARTTLS after confirming SSL on port 465 fails.
 - Add enhanced HTML registration email template and update guest registration
   to send richly formatted confirmation emails using connection testing.
+- Remove "Access Your Profile" button and email support line from the
+  registration confirmation email.

--- a/app/routes/guest.py
+++ b/app/routes/guest.py
@@ -373,17 +373,8 @@ def create_registration_email_content(guest_data):
                         <strong>Conference Helpline:</strong> <a href="tel:+918480002958" style="color: #3b82f6; text-decoration: none;">+91 84800 02958</a>
                     </p>
                     <p style="margin: 5px 0; color: #475569;">
-                        <strong>Email Support:</strong> <a href="mailto:info@magnacode.org" style="color: #3b82f6; text-decoration: none;">info@magnacode.org</a>
-                    </p>
-                    <p style="margin: 5px 0; color: #475569;">
                         <strong>Website:</strong> <a href="https://www.magnacode.org" style="color: #3b82f6; text-decoration: none;">www.magnacode.org</a>
                     </p>
-                </div>
-                <div style="text-align: center; margin: 30px 0;">
-                    <a href="https://www.magnacode.org/guest/login" 
-                       style="background-color: #3b82f6; color: white; padding: 15px 30px; text-decoration: none; border-radius: 25px; font-weight: 600; font-size: 16px; display: inline-block; box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);">
-                        🔑 Access Your Profile
-                    </a>
                 </div>
             </div>
             <div style="background-color: #1f2937; color: #d1d5db; text-align: center; padding: 30px;">

--- a/docs/2025-07-06-remove-profile-link.md
+++ b/docs/2025-07-06-remove-profile-link.md
@@ -1,0 +1,14 @@
+## Remove profile and email contact from registration email
+
+- **Date:** 2025-07-06
+- **Author:** codex
+
+### Summary
+The registration confirmation email no longer includes the "Access Your Profile" button or the "Email Support" line. Attendees will still see the helpline number and website link for assistance.
+
+### Files Affected
+- `app/routes/guest.py`
+- `CHANGELOG.md`
+
+### Rationale
+Simplifying the message keeps the focus on key conference details and avoids sending users to the profile portal from the welcome email.


### PR DESCRIPTION
## Summary
- update registration email to omit the "Access Your Profile" button and email support line
- document the change and update changelog

## Testing
- `pytest -q` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686769484bfc832ca6c37de198b1b02c