### PR TITLE
Add public abstract submission page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,5 @@ All notable changes to this project will be documented in this file.
   to send richly formatted confirmation emails using connection testing.
 - Remove "Access Your Profile" button and email support line from the
   registration confirmation email.
+- Add a standalone abstract submission page that verifies mobile numbers and sends
+  a confirmation email after upload.

--- a/docs/2025-07-07-abstract-submission-page.md
+++ b/docs/2025-07-07-abstract-submission-page.md
@@ -1,0 +1,16 @@
+## Add public abstract submission page
+
+- **Date:** 2025-07-07
+- **Author:** codex
+
+### Summary
+Created a standalone page for abstract submissions that requires only a mobile number. The page verifies the number against existing guests, then allows file upload and sends a confirmation email.
+
+### Files Affected
+- `app/routes/common.py`
+- `templates/abstract_submission.html`
+- `templates/minimal_base.html`
+- `CHANGELOG.md`
+
+### Rationale
+A simple public submission form lets registered attendees upload presentations without logging in. Using a minimal template keeps the page isolated from the rest of the site.

--- a/templates/abstract_submission.html
+++ b/templates/abstract_submission.html
@@ -1,0 +1,30 @@
+{% extends "minimal_base.html" %}
+
+{% block title %}Abstract Submission{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-6">
+    <h2 class="mb-4 text-center">Abstract Submission</h2>
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+    {% if success %}
+    <div class="alert alert-success">{{ success }}</div>
+    {% endif %}
+    <form method="post" enctype="multipart/form-data">
+      <div class="mb-3">
+        <label for="phone" class="form-label">Mobile Number</label>
+        <input type="text" class="form-control" id="phone" name="phone" required>
+      </div>
+      <div class="mb-3">
+        <label for="file" class="form-label">Upload File</label>
+        <input type="file" class="form-control" id="file" name="file" required>
+      </div>
+      <div class="d-grid">
+        <button type="submit" class="btn btn-primary">Submit</button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/minimal_base.html
+++ b/templates/minimal_base.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Submission{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link rel="stylesheet" href="/static/css/styles.css">
+    {% block extra_css %}{% endblock %}
+</head>
+<body>
+    <main class="container py-4">
+        {% include 'components/alerts.html' %}
+        {% block content %}{% endblock %}
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+    {% block extra_js %}{% endblock %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a minimal base template without navigation
- add an abstract submission page that verifies phone numbers and uploads files
- send a confirmation email after successful upload
- document the change

## Testing
- `python test_correct_email.py` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867aac3b128832cad26cddc581e7276