### PR TITLE
Improve abstract submission flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,6 @@ All notable changes to this project will be documented in this file.
   registration confirmation email.
 - Add a standalone abstract submission page that verifies mobile numbers and sends
   a confirmation email after upload.
+- Convert abstract submission into a two-step flow with mobile verification and
+  expanded file type support. Confirmation now includes file details and
+  timestamp.

--- a/docs/2025-07-08-two-step-abstract-submission.md
+++ b/docs/2025-07-08-two-step-abstract-submission.md
@@ -1,0 +1,15 @@
+## Improve abstract submission flow
+
+- **Date:** 2025-07-08
+- **Author:** codex
+
+### Summary
+Converted the abstract submission page into a two-step form. Users now verify their mobile number before uploading files. Allowed file types include JPEG and Mac formats. After submission, a detailed confirmation is shown and emailed to the user.
+
+### Files Affected
+- `app/routes/common.py`
+- `templates/abstract_submission.html`
+- `CHANGELOG.md`
+
+### Rationale
+The previous single form caused confusion when numbers were invalid. A stepwise process ensures only registered attendees can upload files and receive confirmation.

--- a/templates/abstract_submission.html
+++ b/templates/abstract_submission.html
@@ -5,18 +5,34 @@
 {% block content %}
 <div class="row justify-content-center">
   <div class="col-md-6">
-    <h2 class="mb-4 text-center">Abstract Submission</h2>
+    <h2 class="mb-4 text-center">Magnacode Conference Abstract Submission</h2>
+    <p class="text-center">Magnacode proudly hosts an annual conference celebrating advances in medical technology and coding practices.</p>
     {% if error %}
     <div class="alert alert-danger">{{ error }}</div>
     {% endif %}
     {% if success %}
     <div class="alert alert-success">{{ success }}</div>
+    {% if submitted_file %}
+    <p><strong>File:</strong> {{ submitted_file }}<br><strong>Submitted at:</strong> {{ timestamp }}</p>
     {% endif %}
-    <form method="post" enctype="multipart/form-data">
+    {% endif %}
+
+    {% if step == 'check' or not step %}
+    <form method="post">
+      <input type="hidden" name="step" value="check">
       <div class="mb-3">
         <label for="phone" class="form-label">Mobile Number</label>
         <input type="text" class="form-control" id="phone" name="phone" required>
       </div>
+      <div class="d-grid">
+        <button type="submit" class="btn btn-primary">Check Number</button>
+      </div>
+    </form>
+    {% elif step == 'upload' %}
+    <p><strong>Name:</strong> {{ guest_name }}<br><strong>Email:</strong> {{ guest_email }}</p>
+    <form method="post" enctype="multipart/form-data">
+      <input type="hidden" name="step" value="upload">
+      <input type="hidden" name="phone" value="{{ phone }}">
       <div class="mb-3">
         <label for="file" class="form-label">Upload File</label>
         <input type="file" class="form-control" id="file" name="file" required>
@@ -25,6 +41,7 @@
         <button type="submit" class="btn btn-primary">Submit</button>
       </div>
     </form>
+    {% endif %}
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- verify mobile number before allowing upload
- support JPEG and Mac formats for submissions
- display uploaded file details and timestamp
- document new submission flow

## Testing
- `python3 test_correct_email.py` *(fails: Network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867c1ee472c832c84b98e1dd9df8e77