### PR TITLE
Fix broken presentation downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,5 @@ All notable changes to this project will be documented in this file.
 - Convert abstract submission into a two-step flow with mobile verification and
   expanded file type support. Confirmation now includes file details and
   timestamp.
+- Fix presentation download failures by normalizing stored paths and stripping
+  directory components before generating admin download links.

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1555,7 +1555,8 @@ async def presentations_management(request: Request, admin: Dict = Depends(get_c
                 p['guest_name'] = g.get('Name', 'Unknown')
                 p['guest_role'] = g.get('GuestRole', '')
                 p['guest_phone'] = g.get('Phone', '')
-            p['file_url'] = f"/admin/download_presentation/{p.get('file_path')}"
+            file_name = os.path.basename(p.get('file_path', ''))
+            p['file_url'] = f"/admin/download_presentation/{file_name}"
 
         return templates.TemplateResponse(
             "admin/presentations_management.html",
@@ -1807,7 +1808,8 @@ async def single_guest_view(request: Request, admin: Dict = Depends(get_current_
                 reader = csv.DictReader(f)
                 for row in reader:
                     if row.get('guest_id') == guest_id:
-                        row['file_url'] = f"/admin/download_presentation/{row.get('file_path')}"
+                        file_name = os.path.basename(row.get('file_path', ''))
+                        row['file_url'] = f"/admin/download_presentation/{file_name}"
                         presentations.append(row)
 
         # Get guest messages

--- a/docs/2025-07-09-fix-presentation-download.md
+++ b/docs/2025-07-09-fix-presentation-download.md
@@ -1,0 +1,14 @@
+## Fix presentation download links
+
+- **Date:** 2025-07-09
+- **Author:** codex
+
+### Summary
+Normalizes presentation file paths when generating download links for admins. Previously some records stored the full `uploads/presentations` path while others stored only the filename. This inconsistency produced broken links and 404 errors. The admin views now strip any directory components before building the download URL.
+
+### Files Affected
+- `app/routes/admin.py`
+- `CHANGELOG.md`
+
+### Rationale
+Ensures all existing presentation records, regardless of how their path was saved, can be downloaded reliably without re-uploading files.


### PR DESCRIPTION
## Summary
- make admin presentation download links robust to stored paths
- document the fix
- update changelog

## Testing
- `pytest -q` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867c51d5e04832c87440e12039ba2bc