### PR TITLE
Fix admin presentation downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,5 @@ All notable changes to this project will be documented in this file.
   timestamp.
 - Fix presentation download failures by normalizing stored paths and stripping
   directory components before generating admin download links.
+- Handle missing or malformed presentation file paths to prevent broken admin
+  download links.

--- a/docs/2025-07-10-presentation-path-cleanup.md
+++ b/docs/2025-07-10-presentation-path-cleanup.md
@@ -1,0 +1,18 @@
+## Handle malformed presentation paths
+
+- **Date:** 2025-07-10
+- **Author:** codex
+
+### Summary
+Adds additional checks when generating admin presentation links and when serving
+files. Missing or malformed `file_path` fields previously resulted in `/admin/download_presentation/` URLs which produced 404 errors. The logic now falls back to the `file_name` column and strips whitespace to ensure a valid filename.
+
+### Files Affected
+- `app/routes/admin.py`
+- `CHANGELOG.md`
+
+### Rationale
+Some historical presentation records lacked a valid `file_path` or contained
+extra whitespace. This caused broken download links for admins. Sanitizing the
+filename and verifying the field prevents confusion and ensures reliable access
+to uploaded materials.


### PR DESCRIPTION
## Summary
- sanitize `file_path` fields when building admin presentation links
- strip whitespace and fall back to `file_name`
- sanitize file name when serving download
- document fix

## Testing
- `pytest -q` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867c80eb30c832cb6309ddad3656419