### PR TITLE
Fix presentation download links for admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@ All notable changes to this project will be documented in this file.
   directory components before generating admin download links.
 - Handle missing or malformed presentation file paths to prevent broken admin
   download links.
+- Resolve admin presentation downloads when CSV headers were misaligned with older data.

--- a/docs/2025-07-11-presentation-csv-header-fix.md
+++ b/docs/2025-07-11-presentation-csv-header-fix.md
@@ -1,0 +1,19 @@
+## Align presentation CSV headers and handle legacy rows
+
+- **Date:** 2025-07-11
+- **Author:** codex
+
+### Summary
+Presentation uploads were stored using `title` and `description` fields while the
+admin database initializer expected `file_name` and extra metadata columns.
+This mismatch corrupted later rows so admin download links pointed to the title
+text instead of the real file.  A helper now resolves filenames by checking all
+possible columns and the initializer creates the correct headers.
+
+### Files Affected
+- `app/routes/admin.py`
+- `CHANGELOG.md`
+
+### Rationale
+Ensuring consistent CSV headers prevents link corruption and allows previously
+misaligned rows to be downloaded without manual cleanup.


### PR DESCRIPTION
## Summary
- create presentations.csv with correct columns
- resolve real file names when CSV headers are misaligned
- document the presentation CSV header fix
- update changelog

## Testing
- `python -m pytest -q` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867ca911da0832c95dc368a1ef149d9