### PR TITLE
Implement short guest ID and remove batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@ All notable changes to this project will be documented in this file.
 - Handle missing or malformed presentation file paths to prevent broken admin
   download links.
 - Resolve admin presentation downloads when CSV headers were misaligned with older data.
+- Generate shorter 4-character guest IDs and remove the unused Batch field from registration and profile pages.

--- a/app/models/guest.py
+++ b/app/models/guest.py
@@ -2,6 +2,7 @@
 from typing import Dict, Optional, List
 from datetime import datetime
 import uuid
+from app.utils.helpers import generate_random_id
 
 class Guest:
     """Model for guest records"""
@@ -22,7 +23,7 @@ class Guest:
             email: Email address
             guest_role: Role at the conference (Delegate, Faculty, Staff, etc.)
         """
-        self.id = str(uuid.uuid4())[:8].upper()  # Short ID for convenience
+        self.id = generate_random_id(4)
         self.name = name
         self.phone = phone
         self.email = email

--- a/app/routes/guest.py
+++ b/app/routes/guest.py
@@ -6,6 +6,7 @@ from typing import Optional, Dict
 import os
 import logging
 import uuid
+from app.utils.helpers import generate_unique_id
 from datetime import datetime
 import shutil
 import io
@@ -955,7 +956,8 @@ async def register_guest(
                     content={"success": False, "message": "Invalid registration ID"}
                 )
         else:
-            guest_id = str(uuid.uuid4())[:8].upper()
+            existing_ids = [g["ID"] for g in guests_db.read_all()]
+            guest_id = generate_unique_id(existing_ids, 4)
         
         # Create guest record
         guest = {

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -23,6 +23,16 @@ def generate_random_id(length: int = 8) -> str:
     chars = string.ascii_uppercase + string.digits
     return ''.join(random.choice(chars) for _ in range(length))
 
+def generate_unique_id(existing_ids: List[str], length: int = 4) -> str:
+    """Generate a unique alphanumeric ID not present in existing_ids."""
+    if existing_ids is None:
+        existing_ids = []
+
+    attempt = generate_random_id(length)
+    while attempt in existing_ids:
+        attempt = generate_random_id(length)
+    return attempt
+
 def slugify(value: str) -> str:
     """
     Convert a string to a slug - lowercase, with spaces and special chars replaced by hyphens

--- a/docs/2025-07-12-short-id-and-remove-batch.md
+++ b/docs/2025-07-12-short-id-and-remove-batch.md
@@ -1,0 +1,21 @@
+## Shorter guest IDs and remove Batch field
+
+- **Date:** 2025-07-12
+- **Author:** codex
+
+### Summary
+Guest registration now uses a 4-character alphanumeric ID. The form and single guest pages no longer display the Batch field.
+
+### Files Affected
+- `app/models/guest.py`
+- `app/routes/guest.py`
+- `app/utils/helpers.py`
+- `scripts/db_sanity_check.py`
+- `templates/guest_registration.html`
+- `templates/single_guest.html`
+- `templates/admin/single_guest.html`
+- `templates/components/help_system.html`
+- `CHANGELOG.md`
+
+### Rationale
+Shorter IDs are easier to share while remaining unique. Batch information was unused and removed from the interface.

--- a/scripts/db_sanity_check.py
+++ b/scripts/db_sanity_check.py
@@ -3,6 +3,7 @@ import os
 from app.config import Config
 from app.services.csv_db import CSVDatabase
 from app.models.guest import Guest
+from app.utils.helpers import generate_unique_id
 
 
 def run_sanity_check():
@@ -35,7 +36,7 @@ def run_sanity_check():
         gid = row.get('ID')
         if not gid or gid in seen_ids:
             # Generate a new ID if missing or duplicate
-            row['ID'] = Guest().id
+            row['ID'] = generate_unique_id(list(seen_ids))
             updated = True
         seen_ids.add(row['ID'])
 

--- a/templates/admin/single_guest.html
+++ b/templates/admin/single_guest.html
@@ -560,12 +560,7 @@
                                         <div class="editable-field">{{ guest.RegistrationDate or 'Not available' }}</div>
                                     </div>
                                     
-                                    {% if guest.GuestRole == 'Delegates' and guest.Batch %}
-                                    <div class="mb-3">
-                                        <label class="form-label fw-bold text-muted">Batch</label>
-                                        <div class="editable-field">{{ guest.Batch }}</div>
-                                    </div>
-                                    {% endif %}
+                                    {# Batch field removed as it is irrelevant #}
                                     
                                     
                                     {% if guest.CompanyName %}

--- a/templates/components/help_system.html
+++ b/templates/components/help_system.html
@@ -54,7 +54,7 @@
     </ul>
     <p>Required fields depend on the guest role:</p>
     <ul>
-        <li><strong>Delegates:</strong> Name, Phone, Email, Batch</li>
+        <li><strong>Delegates:</strong> Name, Phone, Email</li>
         <li><strong>Sponsors:</strong> Name, Phone, Company Name</li>
         <li><strong>Organizer/Event:</strong> Basic contact information</li>
     </ul>

--- a/templates/guest_registration.html
+++ b/templates/guest_registration.html
@@ -188,10 +188,6 @@
                         
                         <!-- Delegate-specific fields -->
                         <div id="delegate-fields">
-                            <div class="mb-3">
-                                <label for="batch" class="form-label">Batch/Year</label>
-                                <input type="text" class="form-control" id="batch" name="batch" placeholder="Enter your batch or year">
-                            </div>
 
                             <div class="mb-3">
                                 <label for="organization" class="form-label">Organization/Institution</label>
@@ -521,10 +517,6 @@ document.addEventListener('DOMContentLoaded', function() {
         switch (role) {
             case 'Delegate':
                 detailsHTML += `
-                    <tr>
-                        <td><strong>Batch/Year:</strong></td>
-                        <td>${document.getElementById('batch').value || 'Not provided'}</td>
-                    </tr>
                     <tr>
                         <td><strong>Organization:</strong></td>
                         <td>${document.getElementById('organization').value || 'Not provided'}</td>

--- a/templates/single_guest.html
+++ b/templates/single_guest.html
@@ -551,12 +551,7 @@
                                         <div class="editable-field">{{ guest.RegistrationDate or 'Not available' }}</div>
                                     </div>
                                     
-                                    {% if guest.GuestRole == 'Delegates' and guest.Batch %}
-                                    <div class="mb-3">
-                                        <label class="form-label fw-bold text-muted">Batch</label>
-                                        <div class="editable-field">{{ guest.Batch }}</div>
-                                    </div>
-                                    {% endif %}
+                                    {# Batch field removed as no longer used #}
                                     
                                     
                                     {% if guest.CompanyName %}


### PR DESCRIPTION
## Summary
- generate 4-character guest IDs and ensure uniqueness
- remove the Batch field from the registration form and profile pages
- update helper utilities and DB sanity script
- document the change

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867d238dbe8832c830e636abf593602