### PR TITLE
Standardize conference branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Standardize branding to "Magna Endocrine Update 2025" across templates, backend emails, badges, and tests.
 - Fix admin journey update deleting records due to mismatched CSV columns.
   Admin updates now use normalized field names to prevent CSV corruption.
 - Display guest phone numbers on the Presentations Management page for easier contact.

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -2972,7 +2972,7 @@ def create_magnacode_badge(guest: dict) -> Image.Image:
         blue_val = int(30 + (108 * intensity))
         draw.line([(0, y), (width_px, y)], fill=f'#{blue_val:02x}3a8a')
 
-    draw.text((width_px//2, 60), "MAGNACODE 2025", fill='white', anchor="mm", font_size=54)
+    draw.text((width_px//2, 60), "Magna Endocrine Update 2025", fill='white', anchor="mm", font_size=48)
     draw.text((width_px//2, 120), "Healthcare and Education Foundation", fill='white', anchor="mm", font_size=28)
     draw.text((width_px//2, 170), "21st & 22nd September 2025", fill=gold, anchor="mm", font_size=24)
     draw.text((width_px//2, 210), "Bangalore", fill='white', anchor="mm", font_size=22)
@@ -3136,12 +3136,12 @@ def create_magnacode_badge_working(guest: dict) -> Image.Image:
     draw.rectangle([(0, 0), (width_px, header_height)], fill=navy_blue)
 
     try:
-        draw.text((width_px//2, 60), "MAGNACODE 2025", fill='white', anchor="mm", font_size=54)
+        draw.text((width_px//2, 60), "Magna Endocrine Update 2025", fill='white', anchor="mm", font_size=48)
         draw.text((width_px//2, 120), "Healthcare and Education Foundation", fill='white', anchor="mm", font_size=28)
         draw.text((width_px//2, 170), "21st & 22nd September 2025", fill=gold, anchor="mm", font_size=24)
         draw.text((width_px//2, 210), "Bangalore", fill='white', anchor="mm", font_size=22)
     except TypeError:
-        draw.text((width_px//2, 60), "MAGNACODE 2025", fill='white', anchor="mm")
+        draw.text((width_px//2, 60), "Magna Endocrine Update 2025", fill='white', anchor="mm")
         draw.text((width_px//2, 120), "Healthcare and Education Foundation", fill='white', anchor="mm")
         draw.text((width_px//2, 170), "21st & 22nd September 2025", fill=gold, anchor="mm")
         draw.text((width_px//2, 210), "Bangalore", fill='white', anchor="mm")

--- a/app/routes/common.py
+++ b/app/routes/common.py
@@ -1072,7 +1072,7 @@ def create_magnacode_badge(guest: dict) -> Image.Image:
         blue_val = int(30 + (108 * intensity))
         draw.line([(0, y), (width_px, y)], fill=f'#{blue_val:02x}3a8a')
 
-    draw.text((width_px//2, 60), "MAGNACODE 2025", fill='white', anchor="mm", font_size=54)
+    draw.text((width_px//2, 60), "Magna Endocrine Update 2025", fill='white', anchor="mm", font_size=48)
     draw.text((width_px//2, 120), "Healthcare and Education Foundation", fill='white', anchor="mm", font_size=28)
     draw.text((width_px//2, 170), "21st & 22nd September 2025", fill=gold, anchor="mm", font_size=24)
     draw.text((width_px//2, 210), "Bangalore", fill='white', anchor="mm", font_size=22)

--- a/app/routes/guest.py
+++ b/app/routes/guest.py
@@ -243,7 +243,7 @@ def create_registration_email_content(guest_data):
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Registration Confirmation - MAGNACODE 2025</title>
+        <title>Registration Confirmation - Magna Endocrine Update 2025</title>
     </head>
     <body style="margin: 0; padding: 0; background-color: #f5f5f5; font-family: 'Segoe UI', Arial, sans-serif;">
         <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
@@ -252,7 +252,7 @@ def create_registration_email_content(guest_data):
                     MC
                 </div>
                 <h1 style="color: white; margin: 0; font-size: 28px; font-weight: 300;">
-                    MAGNACODE 2025
+                    Magna Endocrine Update 2025
                 </h1>
                 <p style="color: #e0f2fe; margin: 8px 0 0 0; font-size: 16px;">
                     Healthcare and Education Foundation
@@ -269,7 +269,7 @@ def create_registration_email_content(guest_data):
                     Registration Confirmed!
                 </h2>
                 <p style="color: #047857; margin: 0; font-size: 16px;">
-                    Welcome to MAGNACODE 2025, {name}!
+                    Welcome to Magna Endocrine Update 2025, {name}!
                 </p>
             </div>
             <div style="padding: 30px;">
@@ -380,7 +380,7 @@ def create_registration_email_content(guest_data):
             </div>
             <div style="background-color: #1f2937; color: #d1d5db; text-align: center; padding: 30px;">
                 <h3 style="color: #f59e0b; margin: 0 0 15px 0; font-size: 20px;">
-                    MAGNACODE 2025
+                    Magna Endocrine Update 2025
                 </h3>
                 <p style="margin: 5px 0; font-size: 14px;">
                     Healthcare Excellence • Education Innovation
@@ -399,7 +399,7 @@ def create_registration_email_content(guest_data):
                     <a href="tel:+918480002958" style="color: #60a5fa; text-decoration: none; margin: 0 10px;">Support</a>
                 </div>
                 <p style="margin: 10px 0 0 0; font-size: 11px; color: #6b7280;">
-                    This email was sent to {email} because you registered for MAGNACODE 2025.
+                    This email was sent to {email} because you registered for Magna Endocrine Update 2025.
                 </p>
             </div>
         </div>
@@ -1004,7 +1004,7 @@ async def register_guest(
 
                     email_sent = email_service.send_email(
                         email,
-                        "🎉 Registration Confirmed - MAGNACODE 2025",
+                        "🎉 Registration Confirmed - Magna Endocrine Update 2025",
                         email_content
                     )
 
@@ -1055,7 +1055,7 @@ def create_magnacode_badge(guest: dict) -> Image.Image:
         blue_val = int(30 + (108 * intensity))
         draw.line([(0, y), (width_px, y)], fill=f'#{blue_val:02x}3a8a')
 
-    draw.text((width_px//2, 60), "MAGNACODE 2025", fill='white', anchor="mm", font_size=54)
+    draw.text((width_px//2, 60), "Magna Endocrine Update 2025", fill='white', anchor="mm", font_size=48)
     draw.text((width_px//2, 120), "Healthcare and Education Foundation", fill='white', anchor="mm", font_size=28)
     draw.text((width_px//2, 170), "21st & 22nd September 2025", fill=gold, anchor="mm", font_size=24)
     draw.text((width_px//2, 210), "Bangalore", fill='white', anchor="mm", font_size=22)

--- a/docs/2025-08-01-conference-name-update.md
+++ b/docs/2025-08-01-conference-name-update.md
@@ -1,0 +1,23 @@
+## Standardize conference branding
+
+- **Date:** 2025-08-01
+- **Author:** codex
+
+### Summary
+Replaced the old "MAGNACODE 2025" branding with "Magna Endocrine Update 2025" across templates, backend logic, configuration, and tests. The badge generation font size was reduced to fit the longer title.
+
+### Files Affected
+- `templates/components/footer.html`
+- `templates/guest/profile.html`
+- `templates/admin/single_guest.html`
+- `templates/single_guest.html`
+- `app/routes/guest.py`
+- `app/routes/admin.py`
+- `app/routes/common.py`
+- `email_config.ini`
+- `test_correct_email.py`
+- `CHANGELOG.md`
+
+### Rationale
+To maintain consistent branding following the conference name change, hardcoded labels and dynamically generated text were updated. Fonts were adjusted to ensure badges render correctly with the longer name.
+

--- a/email_config.ini
+++ b/email_config.ini
@@ -6,7 +6,7 @@ SMTPPort = 587
 Username = magnacode@magnacode1.qubixvirtual.in
 Password = Hello!@12345
 SenderEmail = magnacode@magnacode1.qubixvirtual.in
-SenderName = MAGNACODE Admin
+SenderName = Magna Endocrine Update 2025 Admin
 
 # Option 2: Non-SSL (if SSL doesn't work)
 # SMTPServer = mail.qubixvirtual.in
@@ -14,4 +14,4 @@ SenderName = MAGNACODE Admin
 # Username = magnacode@magnacode1.qubixvirtual.in
 # Password = Hello!@12345
 # SenderEmail = magnacode@magnacode1.qubixvirtual.in
-# SenderName = MAGNACODE Admin
+# SenderName = Magna Endocrine Update 2025 Admin

--- a/templates/admin/single_guest.html
+++ b/templates/admin/single_guest.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Guest Details - {{ guest.Name }} | MAGNACODE 2025</title>
+    <title>Guest Details - {{ guest.Name }} | Magna Endocrine Update 2025</title>
     
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -415,7 +415,7 @@
                 <div class="container-fluid">
                     <a class="navbar-brand" href="/">
                         <i class="fas fa-graduation-cap me-2"></i>
-                        MAGNACODE 2025
+                        Magna Endocrine Update 2025
                     </a>
                     <div class="navbar-nav ms-auto">
                         <a href="/" class="nav-link">

--- a/templates/components/footer.html
+++ b/templates/components/footer.html
@@ -3,7 +3,7 @@
     <div class="row">
         <div class="col-md-4">
             <h5><i class="fas fa-university me-2"></i> Event Details</h5>
-            <p class="mb-0">MAGNACODE</p>
+            <p class="mb-0">Magna Endocrine Update 2025</p>
             <p class="mb-0">Diabites</p>
             <p class="mb-0">Conference</p>
             <p class="mb-0">Bengaluru</p>
@@ -30,7 +30,7 @@
     <div class="row mt-4">
         <div class="col-12 text-center">
             <!-- In templates/components/footer.html -->
-            <small>&copy; <script>document.write(new Date().getFullYear());</script> MAGNACODE 2025. All rights reserved.</small>
+            <small>&copy; <script>document.write(new Date().getFullYear());</script> Magna Endocrine Update 2025. All rights reserved.</small>
         </div>
     </div>
 </div>

--- a/templates/guest/profile.html
+++ b/templates/guest/profile.html
@@ -343,7 +343,7 @@
                             <div class="d-flex align-items-center justify-content-between">
                                 <h6 class="mb-0">
                                     <i class="fas fa-calendar-alt text-primary me-2"></i>
-                                    MAGNACODE 2025 Schedule
+                                    Magna Endocrine Update 2025 Schedule
                                 </h6>
                                 <span class="badge bg-primary">Sep 20-21</span>
                             </div>

--- a/templates/single_guest.html
+++ b/templates/single_guest.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Guest Details - {{ guest.Name }} | MAGNACODE 2025</title>
+    <title>Guest Details - {{ guest.Name }} | Magna Endocrine Update 2025</title>
     
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -415,7 +415,7 @@
                 <div class="container-fluid">
                     <a class="navbar-brand" href="/">
                         <i class="fas fa-graduation-cap me-2"></i>
-                        MAGNACODE 2025
+                        Magna Endocrine Update 2025
                     </a>
                     <div class="navbar-nav ms-auto">
                         <a href="/" class="nav-link">

--- a/test_correct_email.py
+++ b/test_correct_email.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-MAGNACODE Email test script using correct mail server settings
+Magna Endocrine Update 2025 email test script using correct mail server settings
 """
 
 import smtplib
@@ -35,7 +35,7 @@ def test_email_configurations():
         },
     ]
 
-    print("MAGNACODE 2025 - Correct Email Server Test")
+    print("Magna Endocrine Update 2025 - Email Server Test")
     print("=" * 50)
 
     successful_configs = []
@@ -90,14 +90,14 @@ def send_test_email(config, recipient):
 
     # Create message
     msg = MIMEMultipart('alternative')
-    msg['From'] = f"MAGNACODE Admin <{config['username']}>"
+    msg['From'] = f"Magna Endocrine Update 2025 Admin <{config['username']}>"
     msg['To'] = recipient
-    msg['Subject'] = f"Email Test - MAGNACODE 2025 ({config['name']})"
+    msg['Subject'] = f"Email Test - Magna Endocrine Update 2025 ({config['name']})"
 
     html_content = f"""
     <html>
     <body>
-        <h2>Email Test Successful - MAGNACODE 2025</h2>
+          <h2>Email Test Successful - Magna Endocrine Update 2025</h2>
         <p>This test email was sent successfully using:</p>
         <ul>
             <li><strong>Configuration:</strong> {config['name']}</li>
@@ -108,13 +108,13 @@ def send_test_email(config, recipient):
         </ul>
         <p>Your email configuration is working correctly!</p>
         <br>
-        <p>Best regards,<br>MAGNACODE 2025 Team</p>
+          <p>Best regards,<br>Magna Endocrine Update 2025 Team</p>
     </body>
     </html>
     """
 
     text_content = f"""
-    Email Test Successful - MAGNACODE 2025
+  Email Test Successful - Magna Endocrine Update 2025
 
     This test email was sent successfully using:
     - Configuration: {config['name']}
@@ -126,7 +126,7 @@ def send_test_email(config, recipient):
     Your email configuration is working correctly!
 
     Best regards,
-    MAGNACODE 2025 Team
+  Magna Endocrine Update 2025 Team
     """
 
     msg.attach(MIMEText(text_content, 'plain'))
@@ -160,7 +160,7 @@ def send_test_email(config, recipient):
 
 
 def main():
-    print("Testing MAGNACODE email server configurations...")
+    print("Testing Magna Endocrine Update 2025 email server configurations...")
 
     # Test connections
     successful_configs = test_email_configurations()


### PR DESCRIPTION
## Summary
- update conference name in frontend templates
- adjust badge text in guest/admin/common routes
- refresh email sender and tests with new branding
- note branding update in CHANGELOG and docs

## Testing
- `python3 -m py_compile app/routes/guest.py app/routes/admin.py app/routes/common.py test_correct_email.py`

------
https://chatgpt.com/codex/tasks/task_e_688cb97996b0832cb583093330dd3d6b