### PR TITLE
Enforce unique contact details for guest registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,4 @@ All notable changes to this project will be documented in this file.
 - Resolve admin presentation downloads when CSV headers were misaligned with older data.
 - Generate shorter 4-character guest IDs and remove the unused Batch field from registration and profile pages.
 - Update admin dashboard stats: delegates count replaces checked-in, and new attendance count covers faculty and delegates with check-in or meal coupon.
+- Enforce unique phone and KMC numbers during guest registration with server validation and frontend error messaging.

--- a/docs/2025-08-02-guest-unique-contact.md
+++ b/docs/2025-08-02-guest-unique-contact.md
@@ -1,0 +1,15 @@
+## Enforce unique guest contact info
+
+- **Date:** 2025-08-02
+- **Author:** codex
+
+### Summary
+Adds validation to reject duplicate phone or KMC numbers during guest registration and surfaces server errors to users on the registration page.
+
+### Files Affected
+- `app/routes/guest.py`
+- `templates/guest_registration.html`
+- `CHANGELOG.md`
+
+### Rationale
+Ensuring unique contact details prevents conflicting records and improves data integrity while offering clear feedback to registrants.

--- a/templates/guest_registration.html
+++ b/templates/guest_registration.html
@@ -597,9 +597,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 method: 'POST',
                 body: formData
             })
-            .then(response => response.json())
-            .then(data => {
-                if (data.success) {
+            .then(async response => {
+                const data = await response.json();
+                if (response.ok && data.success) {
                     // Go to success step
                     formSteps.forEach(step => step.classList.remove('active'));
                     document.querySelector('.form-step[data-step="4"]').classList.add('active');


### PR DESCRIPTION
## Summary
- validate phone and KMC numbers against existing guests before registration
- surface server-side validation errors on the registration form
- document unique contact validation in changelog and change record

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f49bf5e30832cb916cc3812c2446c