### PR TITLE
Display abstract upload step images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@ All notable changes to this project will be documented in this file.
 - Update admin dashboard stats: delegates count replaces checked-in, and new attendance count covers faculty and delegates with check-in or meal coupon.
 - Enforce unique phone and KMC numbers during guest registration with server validation and frontend error messaging.
 - Generate badges using role-specific background images and reposition guest details and QR codes accordingly.
+- Add step-by-step abstract upload guide images below mobile number verification on the abstract submission page.

--- a/docs/2025-08-06-abstract-upload-guide-images.md
+++ b/docs/2025-08-06-abstract-upload-guide-images.md
@@ -1,0 +1,15 @@
+## Add visual abstract upload guide
+
+- **Date:** 2025-08-06
+- **Author:** assistant
+
+### Summary
+Display four step images beneath the mobile number verification button on the abstract submission page to guide users through uploading their abstracts on both mobile and desktop devices.
+
+### Files Affected
+- `templates/abstract_submission.html`
+- `CHANGELOG.md`
+
+### Rationale
+Providing visual instructions makes the submission process clearer, especially for first-time users, and ensures a consistent experience across devices.
+

--- a/templates/abstract_submission.html
+++ b/templates/abstract_submission.html
@@ -28,6 +28,22 @@
         <button type="submit" class="btn btn-primary">Check Number</button>
       </div>
     </form>
+    <div class="mt-4">
+      <div class="row row-cols-2 row-cols-md-4 g-3 text-center">
+        <div class="col">
+          <img src="{{ url_for('static', filename='images/step1.jpeg') }}" alt="Step 1" class="img-fluid rounded shadow-sm">
+        </div>
+        <div class="col">
+          <img src="{{ url_for('static', filename='images/step2.jpeg') }}" alt="Step 2" class="img-fluid rounded shadow-sm">
+        </div>
+        <div class="col">
+          <img src="{{ url_for('static', filename='images/step3.jpeg') }}" alt="Step 3" class="img-fluid rounded shadow-sm">
+        </div>
+        <div class="col">
+          <img src="{{ url_for('static', filename='images/step4.jpeg') }}" alt="Step 4" class="img-fluid rounded shadow-sm">
+        </div>
+      </div>
+    </div>
     {% elif step == 'upload' %}
     <p><strong>Name:</strong> {{ guest_name }}<br><strong>Email:</strong> {{ guest_email }}</p>
     <form method="post" enctype="multipart/form-data">


### PR DESCRIPTION
## Summary
- show step-by-step abstract upload images below the mobile number check button
- document the new guidance

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68939ad79e24832c8b015c684e145b52