### PR TITLE
Fix static path parameter in abstract submission template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,4 @@ All notable changes to this project will be documented in this file.
 - Enforce unique phone and KMC numbers during guest registration with server validation and frontend error messaging.
 - Generate badges using role-specific background images and reposition guest details and QR codes accordingly.
 - Add step-by-step abstract upload guide images below mobile number verification on the abstract submission page.
+- Fix abstract submission template's static asset links by using the correct `path` parameter with `url_for` to avoid missing route errors.

--- a/templates/abstract_submission.html
+++ b/templates/abstract_submission.html
@@ -31,16 +31,16 @@
     <div class="mt-4">
       <div class="row row-cols-2 row-cols-md-4 g-3 text-center">
         <div class="col">
-          <img src="{{ url_for('static', filename='images/step1.jpeg') }}" alt="Step 1" class="img-fluid rounded shadow-sm">
+          <img src="{{ url_for('static', path='images/step1.jpeg') }}" alt="Step 1" class="img-fluid rounded shadow-sm">
         </div>
         <div class="col">
-          <img src="{{ url_for('static', filename='images/step2.jpeg') }}" alt="Step 2" class="img-fluid rounded shadow-sm">
+          <img src="{{ url_for('static', path='images/step2.jpeg') }}" alt="Step 2" class="img-fluid rounded shadow-sm">
         </div>
         <div class="col">
-          <img src="{{ url_for('static', filename='images/step3.jpeg') }}" alt="Step 3" class="img-fluid rounded shadow-sm">
+          <img src="{{ url_for('static', path='images/step3.jpeg') }}" alt="Step 3" class="img-fluid rounded shadow-sm">
         </div>
         <div class="col">
-          <img src="{{ url_for('static', filename='images/step4.jpeg') }}" alt="Step 4" class="img-fluid rounded shadow-sm">
+          <img src="{{ url_for('static', path='images/step4.jpeg') }}" alt="Step 4" class="img-fluid rounded shadow-sm">
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Correct static image references in abstract submission template using `url_for`'s `path` parameter
- Document fix in CHANGELOG

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68939e275600832ca33e9cf4f34c1219