### PR TITLE
Add guest ID lookup by mobile number on login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,4 @@ All notable changes to this project will be documented in this file.
 - Generate badges using role-specific background images and reposition guest details and QR codes accordingly.
 - Add step-by-step abstract upload guide images below mobile number verification on the abstract submission page.
 - Fix abstract submission template's static asset links by using the correct `path` parameter with `url_for` to avoid missing route errors.
+- Provide a mobile number lookup on the guest login page to fetch forgotten IDs instantly.

--- a/app/routes/guest.py
+++ b/app/routes/guest.py
@@ -411,11 +411,30 @@ def create_registration_email_content(guest_data):
     return html_content
 
 # Routes
+@router.get("/fetch-id")
+async def fetch_guest_id(phone: str):
+    """Fetch guest ID by phone number."""
+    try:
+        guests = guests_db.read_all()
+        guest = next((g for g in guests if g["Phone"] == phone), None)
+        if guest:
+            return JSONResponse({"success": True, "guest_id": guest["ID"]})
+        return JSONResponse(
+            {"success": False, "message": "Wrong mobile number"},
+            status_code=404,
+        )
+    except Exception as e:
+        logger.error(f"Fetch guest ID error: {str(e)}")
+        return JSONResponse(
+            {"success": False, "message": "An error occurred"},
+            status_code=500,
+        )
+
 @router.get("/login", response_class=HTMLResponse)
 async def login_page(request: Request):
     """Guest login page"""
     return templates.TemplateResponse(
-        "guest/login.html", 
+        "guest/login.html",
         {
             "request": request,
             "active_page": "login"

--- a/templates/guest/login.html
+++ b/templates/guest/login.html
@@ -57,6 +57,24 @@
         
         <div class="card mt-4 shadow-sm border-0">
             <div class="card-body">
+                <h5 class="card-title"><i class="fas fa-search text-primary me-2"></i> Forgot Guest ID?</h5>
+                <div class="row g-2 align-items-center">
+                    <div class="col-md-5">
+                        <input type="text" class="form-control" id="fetch_phone" placeholder="Enter phone number">
+                    </div>
+                    <div class="col-md-5">
+                        <input type="text" class="form-control" id="fetched_id" placeholder="Guest ID" readonly>
+                    </div>
+                    <div class="col-md-2 d-grid">
+                        <button class="btn btn-outline-primary" id="fetch_id_btn">Fetch ID</button>
+                    </div>
+                </div>
+                <div class="mt-2"><small id="fetch_id_message"></small></div>
+            </div>
+        </div>
+
+        <div class="card mt-4 shadow-sm border-0">
+            <div class="card-body">
                 <h5 class="card-title"><i class="fas fa-info-circle text-primary me-2"></i> Login Instructions</h5>
                 <p class="card-text">To login, please enter your Guest ID and the phone number you provided during registration.</p>
                 <ul class="mb-0">
@@ -86,12 +104,54 @@ document.addEventListener('DOMContentLoaded', function() {
             this.value = this.value.replace(/[^0-9]/g, '').substring(0, 10);
         });
     }
-    
+
+    // Fetch guest ID by phone number
+    const fetchPhoneInput = document.getElementById('fetch_phone');
+    const fetchIdBtn = document.getElementById('fetch_id_btn');
+    const fetchedIdInput = document.getElementById('fetched_id');
+    const fetchIdMessage = document.getElementById('fetch_id_message');
+
+    if (fetchPhoneInput) {
+        fetchPhoneInput.addEventListener('input', function() {
+            this.value = this.value.replace(/[^0-9]/g, '').substring(0, 10);
+        });
+    }
+
+    if (fetchIdBtn) {
+        fetchIdBtn.addEventListener('click', async function(e) {
+            e.preventDefault();
+            fetchIdMessage.textContent = '';
+            fetchIdMessage.className = '';
+            const phone = fetchPhoneInput.value;
+            if (phone.length !== 10) {
+                fetchedIdInput.value = '';
+                fetchIdMessage.textContent = 'Enter a valid 10-digit mobile number';
+                fetchIdMessage.className = 'text-danger';
+                return;
+            }
+            try {
+                const response = await fetch(`/guest/fetch-id?phone=${phone}`);
+                const data = await response.json();
+                if (response.ok && data.success) {
+                    fetchedIdInput.value = data.guest_id;
+                } else {
+                    fetchedIdInput.value = '';
+                    fetchIdMessage.textContent = data.message || 'Wrong mobile number';
+                    fetchIdMessage.className = 'text-danger';
+                }
+            } catch (error) {
+                fetchedIdInput.value = '';
+                fetchIdMessage.textContent = 'Error fetching ID';
+                fetchIdMessage.className = 'text-danger';
+            }
+        });
+    }
+
     // Focus on Guest ID field
     const guestIdInput = document.getElementById('guest_id');
     if (guestIdInput) {
         guestIdInput.focus();
     }
 });
-</script>
-{% endblock %}
+  </script>
+  {% endblock %}


### PR DESCRIPTION
## Summary
- allow guests to retrieve their ID by phone via new `/guest/fetch-id` endpoint
- add "Forgot Guest ID" card on login page with instant ID lookup
- document guest ID lookup feature in changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893a71a5bcc832c95dfa84529304ab0