### PR TITLE
feat: add presentation approval workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,4 @@ All notable changes to this project will be documented in this file.
 - Add step-by-step abstract upload guide images below mobile number verification on the abstract submission page.
 - Fix abstract submission template's static asset links by using the correct `path` parameter with `url_for` to avoid missing route errors.
 - Provide a mobile number lookup on the guest login page to fetch forgotten IDs instantly.
+- Introduce presentation approval workflow with dedicated approver login and CSV fields for selection status, marks, remarks, and approval date.

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ import time
 import csv
 
 from app.config import Config
-from app.routes import admin, guest, common
+from app.routes import admin, guest, common, approvals
 from app.services.csv_db import CSVDatabase
 # Replace the current templates initialization in main.py
 from app.templates import templates
@@ -134,6 +134,7 @@ templates.env.globals["now"] = datetime.now()
 app.include_router(common.router)
 app.include_router(guest.router)
 app.include_router(admin.router)
+app.include_router(approvals.router)
 # if os.path.exists(os.path.join(app.config.get('PATHS', 'TemplatesDir'), "faculty")):
 #     from app.routes import faculty
 #     app.include_router(faculty.router)

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -528,8 +528,17 @@ def reset_related_databases():
 
         presentations_csv = os.path.join(data_dir, "presentations.csv")
         presentation_headers = [
-            "id", "guest_id", "title", "description", "file_path",
-            "file_type", "upload_date"
+            "id",
+            "guest_id",
+            "title",
+            "description",
+            "file_path",
+            "file_type",
+            "upload_date",
+            "selected_status",
+            "marks_allotted",
+            "remarks_by",
+            "approval_date",
         ]
         create_empty_csv(presentations_csv, presentation_headers)
 

--- a/app/routes/approvals.py
+++ b/app/routes/approvals.py
@@ -1,0 +1,90 @@
+# app/routes/approvals.py
+from fastapi import APIRouter, Request, Form
+from fastapi.responses import HTMLResponse, RedirectResponse
+from app.config import Config
+from app.templates import templates
+from datetime import datetime
+import csv
+import os
+
+router = APIRouter()
+config = Config()
+PRESENTATIONS_CSV = os.path.join(os.path.dirname(config.get('DATABASE', 'CSVPath')), 'presentations.csv')
+
+@router.get("/approvals/login", response_class=HTMLResponse)
+async def approver_login_page(request: Request):
+    """Render the login page for presentation approvers."""
+    return templates.TemplateResponse("admin/approver_login.html", {"request": request})
+
+@router.post("/approvals/login")
+async def process_approver_login(request: Request, username: str = Form(...), password: str = Form(...)):
+    """Process login credentials for approvers."""
+    if username in ["abstract01", "abstract02", "abstract03"] and password == "magna123!@abs":
+        response = RedirectResponse(url="/approvals/dashboard", status_code=303)
+        response.set_cookie(key="approver_user", value=username)
+        return response
+    return templates.TemplateResponse("admin/approver_login.html", {"request": request, "error": "Invalid credentials"})
+
+@router.get("/approvals/dashboard", response_class=HTMLResponse)
+async def approvals_dashboard(request: Request):
+    """Display all presentations for approval."""
+    approver_user = request.cookies.get("approver_user")
+    if not approver_user:
+        return RedirectResponse(url="/approvals/login")
+
+    presentations = []
+    if os.path.exists(PRESENTATIONS_CSV):
+        with open(PRESENTATIONS_CSV, mode='r', newline='', encoding='utf-8') as file:
+            reader = csv.DictReader(file)
+            for row in reader:
+                presentations.append(row)
+
+    return templates.TemplateResponse(
+        "admin/presentation_approval.html",
+        {"request": request, "presentations": presentations, "approver": approver_user}
+    )
+
+@router.post("/approvals/save")
+async def save_approval(
+    request: Request,
+    presentation_id: str = Form(...),
+    status: str = Form(...),
+    marks: int = Form(...),
+    remarks: str = Form(...)
+):
+    """Save approval details for a presentation. Once saved, it cannot be modified."""
+    approver_user = request.cookies.get("approver_user")
+    if not approver_user:
+        return RedirectResponse(url="/approvals/login")
+
+    rows = []
+    fieldnames = []
+    if os.path.exists(PRESENTATIONS_CSV):
+        with open(PRESENTATIONS_CSV, mode='r', newline='', encoding='utf-8') as file:
+            reader = csv.DictReader(file)
+            fieldnames = reader.fieldnames or []
+            if "selected_status" not in fieldnames:
+                fieldnames.extend(["selected_status", "marks_allotted", "remarks_by", "approval_date"])
+            for row in reader:
+                if row["id"] == presentation_id:
+                    # Prevent modifications if already approved
+                    if row.get("selected_status") or row.get("marks_allotted") or row.get("remarks_by"):
+                        rows.append(row)
+                        continue
+                    row["selected_status"] = status
+                    row["marks_allotted"] = str(marks)
+                    row["remarks_by"] = f"{remarks} ({approver_user})"
+                    row["approval_date"] = datetime.now().isoformat()
+                rows.append(row)
+    else:
+        fieldnames = [
+            "id", "guest_id", "title", "description", "file_path", "file_type", "upload_date",
+            "selected_status", "marks_allotted", "remarks_by", "approval_date"
+        ]
+
+    with open(PRESENTATIONS_CSV, mode='w', newline='', encoding='utf-8') as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    return RedirectResponse(url="/approvals/dashboard", status_code=303)

--- a/app/routes/common.py
+++ b/app/routes/common.py
@@ -1236,12 +1236,36 @@ async def submit_abstract(
     if not os.path.exists(PRESENTATIONS_CSV):
         with open(PRESENTATIONS_CSV, mode='w', newline='', encoding='utf-8') as f:
             writer = csv.writer(f)
-            writer.writerow(["id", "guest_id", "title", "description", "file_path", "file_type", "upload_date"])
+            writer.writerow([
+                "id",
+                "guest_id",
+                "title",
+                "description",
+                "file_path",
+                "file_type",
+                "upload_date",
+                "selected_status",
+                "marks_allotted",
+                "remarks_by",
+                "approval_date",
+            ])
 
     with open(PRESENTATIONS_CSV, mode='a', newline='', encoding='utf-8') as f:
         writer = csv.DictWriter(
             f,
-            fieldnames=["id", "guest_id", "title", "description", "file_path", "file_type", "upload_date"],
+            fieldnames=[
+                "id",
+                "guest_id",
+                "title",
+                "description",
+                "file_path",
+                "file_type",
+                "upload_date",
+                "selected_status",
+                "marks_allotted",
+                "remarks_by",
+                "approval_date",
+            ],
         )
         writer.writerow(
             {
@@ -1252,6 +1276,10 @@ async def submit_abstract(
                 "file_path": unique_name,
                 "file_type": ext.lstrip("."),
                 "upload_date": datetime.now().isoformat(),
+                "selected_status": "",
+                "marks_allotted": "",
+                "remarks_by": "",
+                "approval_date": "",
             }
         )
 

--- a/app/routes/guest.py
+++ b/app/routes/guest.py
@@ -720,10 +720,37 @@ async def upload_presentation(
         if not os.path.exists(PRESENTATIONS_CSV):
             with open(PRESENTATIONS_CSV, mode='w', newline='', encoding='utf-8') as file:
                 writer = csv.writer(file)
-                writer.writerow(["id", "guest_id", "title", "description", "file_path", "file_type", "upload_date"])
-        
+                writer.writerow([
+                    "id",
+                    "guest_id",
+                    "title",
+                    "description",
+                    "file_path",
+                    "file_type",
+                    "upload_date",
+                    "selected_status",
+                    "marks_allotted",
+                    "remarks_by",
+                    "approval_date",
+                ])
+
         with open(PRESENTATIONS_CSV, mode='a', newline='', encoding='utf-8') as file:
-            writer = csv.DictWriter(file, fieldnames=["id", "guest_id", "title", "description", "file_path", "file_type", "upload_date"])
+            writer = csv.DictWriter(
+                file,
+                fieldnames=[
+                    "id",
+                    "guest_id",
+                    "title",
+                    "description",
+                    "file_path",
+                    "file_type",
+                    "upload_date",
+                    "selected_status",
+                    "marks_allotted",
+                    "remarks_by",
+                    "approval_date",
+                ],
+            )
             writer.writerow({
                 "id": str(uuid.uuid4()),
                 "guest_id": guest["ID"],
@@ -731,7 +758,11 @@ async def upload_presentation(
                 "description": description,
                 "file_path": filename,
                 "file_type": file_type,
-                "upload_date": datetime.now().isoformat()
+                "upload_date": datetime.now().isoformat(),
+                "selected_status": "",
+                "marks_allotted": "",
+                "remarks_by": "",
+                "approval_date": "",
             })
         
         return JSONResponse(

--- a/docs/2025-08-14-presentation-approval-module.md
+++ b/docs/2025-08-14-presentation-approval-module.md
@@ -1,0 +1,6 @@
+## Add presentation approval workflow
+
+- Introduced dedicated approver login with hardcoded credentials for abstract reviewers.
+- Added dashboard to review uploaded presentations and record selection status, marks, remarks, and timestamp.
+- Extended `presentations.csv` with columns: `selected_status`, `marks_allotted`, `remarks_by`, and `approval_date`.
+- Stored approvals are immutable and require confirmation before saving.

--- a/templates/admin/approver_login.html
+++ b/templates/admin/approver_login.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block title %}Approver Login{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <div class="card shadow-lg border-0">
+            <div class="card-header bg-dark text-white text-center py-3">
+                <h4 class="mb-0">Presentation Approver Login</h4>
+            </div>
+            <div class="card-body p-4">
+                {% if error %}
+                <div class="alert alert-danger">{{ error }}</div>
+                {% endif %}
+                <form method="post" action="/approvals/login">
+                    <div class="mb-3">
+                        <label for="username" class="form-label">Username</label>
+                        <input type="text" class="form-control" id="username" name="username" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="password" class="form-label">Password</label>
+                        <input type="password" class="form-control" id="password" name="password" required>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-100">Login</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/presentation_approval.html
+++ b/templates/admin/presentation_approval.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %}
+
+{% block title %}Presentation Approvals{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <h1 class="h3 mb-4">Presentation Approval Dashboard</h1>
+    <div class="table-responsive">
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>Title</th>
+                    <th>Status</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for p in presentations %}
+                <tr>
+                    <td>{{ p.title }}</td>
+                    <td>{{ p.selected_status or 'Pending' }}</td>
+                    <td>
+                        <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#approvalModal-{{ p.id }}">
+                            Approve
+                        </button>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+{% for p in presentations %}
+<div class="modal fade" id="approvalModal-{{ p.id }}" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Approve Presentation</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form action="/approvals/save" method="post" onsubmit="return confirm('Are you sure you want to save? This action cannot be undone.');">
+                <div class="modal-body">
+                    <input type="hidden" name="presentation_id" value="{{ p.id }}">
+                    <div class="mb-3">
+                        <a href="/static/uploads/presentations/{{ p.file_path }}" class="btn btn-info" download>Download Presentation</a>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Status</label>
+                        <div>
+                            <button type="button" class="btn btn-success me-2" onclick="this.form.status.value='Selected'">Selected</button>
+                            <button type="button" class="btn btn-danger" onclick="this.form.status.value='Not Selected'">Not Selected</button>
+                            <input type="hidden" name="status" required>
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="marks" class="form-label">Marks (0-10)</label>
+                        <input type="number" class="form-control" name="marks" min="0" max="10" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="remarks" class="form-label">Remarks by (Name)</label>
+                        <input type="text" class="form-control" name="remarks" required>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                    <button type="submit" class="btn btn-primary">Save Approval</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endfor %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add presentation approval routes and templates with approver login
- extend presentations.csv with selection, marks, remarks, and approval date
- document approvals module in changelog and docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d6dd047f0832cb5d5154197030924