### PR TITLE
Lock and display presentation approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,4 @@ All notable changes to this project will be documented in this file.
 - Fix abstract submission template's static asset links by using the correct `path` parameter with `url_for` to avoid missing route errors.
 - Provide a mobile number lookup on the guest login page to fetch forgotten IDs instantly.
 - Introduce presentation approval workflow with dedicated approver login and CSV fields for selection status, marks, remarks, and approval date.
+- Lock presentation approvals after first decision and display approval status and remarks on admin and guest views with direct links to the review page.

--- a/templates/admin/presentation_approval.html
+++ b/templates/admin/presentation_approval.html
@@ -11,6 +11,7 @@
                 <tr>
                     <th>Title</th>
                     <th>Status</th>
+                    <th>Remarks</th>
                     <th>Actions</th>
                 </tr>
             </thead>
@@ -19,10 +20,17 @@
                 <tr>
                     <td>{{ p.title }}</td>
                     <td>{{ p.selected_status or 'Pending' }}</td>
+                    <td>{{ p.remarks_by or 'N/A' }}</td>
                     <td>
+                        {% if p.selected_status %}
+                        <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#approvalModal-{{ p.id }}">
+                            View
+                        </button>
+                        {% else %}
                         <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#approvalModal-{{ p.id }}">
                             Approve
                         </button>
+                        {% endif %}
                     </td>
                 </tr>
                 {% endfor %}
@@ -45,6 +53,13 @@
                     <div class="mb-3">
                         <a href="/static/uploads/presentations/{{ p.file_path }}" class="btn btn-info" download>Download Presentation</a>
                     </div>
+                    {% if p.selected_status %}
+                    <div class="mb-3">
+                        <p><strong>Status:</strong> {{ p.selected_status }}</p>
+                        <p><strong>Marks:</strong> {{ p.marks_allotted }}</p>
+                        <p><strong>Remarks:</strong> {{ p.remarks_by }}</p>
+                    </div>
+                    {% else %}
                     <div class="mb-3">
                         <label class="form-label">Status</label>
                         <div>
@@ -61,14 +76,33 @@
                         <label for="remarks" class="form-label">Remarks by (Name)</label>
                         <input type="text" class="form-control" name="remarks" required>
                     </div>
+                    {% endif %}
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                    {% if not p.selected_status %}
                     <button type="submit" class="btn btn-primary">Save Approval</button>
+                    {% endif %}
                 </div>
             </form>
         </div>
     </div>
 </div>
 {% endfor %}
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('id');
+    if (id) {
+        const modal = document.getElementById(`approvalModal-${id}`);
+        if (modal) {
+            const m = new bootstrap.Modal(modal);
+            m.show();
+        }
+    }
+});
+</script>
 {% endblock %}

--- a/templates/admin/presentations_management.html
+++ b/templates/admin/presentations_management.html
@@ -32,7 +32,10 @@
                         <th>Role</th>
                         <th>Title</th>
                         <th>Uploaded</th>
+                        <th>Status</th>
+                        <th>Remarks</th>
                         <th>File</th>
+                        <th>Approval</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -43,10 +46,13 @@
                         <td>{{ p.guest_role }}</td>
                         <td>{{ p.title }}</td>
                         <td>{{ p.upload_date }}</td>
+                        <td>{{ p.selected_status or 'Pending' }}</td>
+                        <td>{{ p.remarks_by or 'N/A' }}</td>
                         <td><a href="{{ p.file_url }}" class="btn btn-sm btn-primary"><i class="fas fa-download me-1"></i>Download</a></td>
+                        <td><a href="/approvals/dashboard?id={{ p.id }}" class="btn btn-sm btn-outline-primary">Review</a></td>
                     </tr>
                 {% else %}
-                    <tr><td colspan="6" class="text-center">No presentations found.</td></tr>
+                    <tr><td colspan="9" class="text-center">No presentations found.</td></tr>
                 {% endfor %}
                 </tbody>
             </table>

--- a/templates/admin/single_guest.html
+++ b/templates/admin/single_guest.html
@@ -1145,7 +1145,10 @@
                                 <tr>
                                     <th>Title</th>
                                     <th>Uploaded</th>
+                                    <th>Status</th>
+                                    <th>Remarks</th>
                                     <th>File</th>
+                                    <th>Approval</th>
                                 </tr>
                                 </thead>
                                 <tbody>
@@ -1153,10 +1156,13 @@
                                 <tr>
                                     <td>{{ p.title }}</td>
                                     <td>{{ p.upload_date }}</td>
+                                    <td>{{ p.selected_status or 'Pending' }}</td>
+                                    <td>{{ p.remarks_by or 'N/A' }}</td>
                                     <td><a href="{{ p.file_url }}" class="btn btn-sm btn-primary"><i class="fas fa-download me-1"></i>Download</a></td>
+                                    <td><a href="/approvals/dashboard?id={{ p.id }}" class="btn btn-sm btn-outline-primary">Review</a></td>
                                 </tr>
                                 {% else %}
-                                <tr><td colspan="3" class="text-center">No presentations found.</td></tr>
+                                <tr><td colspan="6" class="text-center">No presentations found.</td></tr>
                                 {% endfor %}
                                 </tbody>
                             </table>

--- a/templates/guest/presentations.html
+++ b/templates/guest/presentations.html
@@ -34,6 +34,17 @@
                         <p class="card-text small">
                             <i class="fas fa-calendar-alt me-1"></i> {{ presentation.upload_date }}
                         </p>
+                        <p class="card-text small">
+                            Status:
+                            {% set status = presentation.selected_status or 'Pending' %}
+                            {% if status == 'Selected' %}
+                                <span class="badge bg-success">{{ status }}</span>
+                            {% elif status == 'Not Selected' %}
+                                <span class="badge bg-danger">{{ status }}</span>
+                            {% else %}
+                                <span class="badge bg-secondary">{{ status }}</span>
+                            {% endif %}
+                        </p>
                     </div>
                     <div class="card-footer bg-white">
                         <a href="{{ presentation.file_url }}" class="btn btn-sm btn-outline-primary" target="_blank">


### PR DESCRIPTION
## Summary
- prevent re-approving presentations once a decision is recorded
- surface approval status and remarks on admin and guest views
- link admin listings to the approval modal for quick review

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d788bcd10832c9efe0566bf10d06c