### PR TITLE
Move KMC Number field to first registration step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,4 @@ All notable changes to this project will be documented in this file.
 - Provide a mobile number lookup on the guest login page to fetch forgotten IDs instantly.
 - Introduce presentation approval workflow with dedicated approver login and CSV fields for selection status, marks, remarks, and approval date.
 - Lock presentation approvals after first decision and display approval status and remarks on admin and guest views with direct links to the review page.
+- Show KMC Number field in the first step of guest registration for Delegate and Faculty roles.

--- a/docs/2025-08-14-kmc-number-first-step.md
+++ b/docs/2025-08-14-kmc-number-first-step.md
@@ -1,0 +1,14 @@
+## Move KMC Number field to first registration step
+
+- **Date:** 2025-08-14
+- **Author:** codex
+
+### Summary
+Relocated the KMC Number input from the second step of the guest registration form to the first step. The field now appears immediately when the user selects either the Delegate or Faculty role, and validation is enforced accordingly.
+
+### Files Affected
+- `templates/guest_registration.html`
+- `CHANGELOG.md`
+
+### Rationale
+Collecting KMC numbers early improves data accuracy and streamlines registration for delegates and faculty by ensuring their professional credentials are captured before proceeding.

--- a/templates/guest_registration.html
+++ b/templates/guest_registration.html
@@ -171,7 +171,15 @@
                             <input type="email" class="form-control" id="email" name="email" placeholder="Enter email address">
                             <div class="form-text">Optional, but recommended for updates</div>
                         </div>
-                        
+
+                        <div id="kmc-field" class="mb-3" style="display: none;">
+                            <label for="kmc_number" class="form-label">KMC Number</label>
+                            <input type="text" class="form-control" id="kmc_number" name="kmc_number" placeholder="Enter your KMC number" required>
+                            <div class="invalid-feedback">
+                                Please enter your KMC number.
+                            </div>
+                        </div>
+
                         <div class="d-flex justify-content-between mt-4">
                             <a href="/" class="btn btn-outline-secondary">
                                 <i class="fas fa-arrow-left me-1"></i> Cancel
@@ -193,11 +201,6 @@
                                 <label for="organization" class="form-label">Organization/Institution</label>
                                 <input type="text" class="form-control" id="organization" name="organization" placeholder="Enter your current organization">
                             </div>
-
-                            <div class="mb-3">
-                                <label for="delegateKmcNumber" class="form-label">KMC Number</label>
-                                <input type="text" class="form-control" id="delegateKmcNumber" name="kmc_number" placeholder="Enter your KMC number" required disabled>
-                            </div>
                         </div>
                         
                         <!-- Faculty-specific fields -->
@@ -215,11 +218,6 @@
                             <div class="mb-3">
                                 <label for="specialty" class="form-label">Specialty/Expertise</label>
                                 <input type="text" class="form-control" id="specialty" name="specialty" placeholder="Enter your specialty or field of expertise">
-                            </div>
-
-                            <div class="mb-3">
-                                <label for="facultyKmcNumber" class="form-label">KMC Number</label>
-                                <input type="text" class="form-control" id="facultyKmcNumber" name="kmc_number" placeholder="Enter your KMC number" required disabled>
                             </div>
 
                             <div class="mb-3">
@@ -386,8 +384,6 @@ document.addEventListener('DOMContentLoaded', function() {
     const delegateFields = document.getElementById('delegate-fields');
     const facultyFields = document.getElementById('faculty-fields');
     const sponsorFields = document.getElementById('sponsor-fields');
-    const delegateKmc = document.getElementById('delegateKmcNumber');
-    const facultyKmc = document.getElementById('facultyKmcNumber');
 
     if (guestRoleSelect) {
         guestRoleSelect.addEventListener('change', function() {
@@ -396,19 +392,37 @@ document.addEventListener('DOMContentLoaded', function() {
             facultyFields.style.display = 'none';
             sponsorFields.style.display = 'none';
 
-            // Disable all KMC inputs by default
-            if (delegateKmc) { delegateKmc.disabled = true; delegateKmc.required = false; }
-            if (facultyKmc) { facultyKmc.disabled = true; facultyKmc.required = false; }
+            // Also hide the KMC field initially
+            const kmcField = document.getElementById('kmc-field');
+            if (kmcField) {
+                kmcField.style.display = 'none';
+                const kmcInput = kmcField.querySelector('input');
+                if (kmcInput) {
+                    kmcInput.required = false;
+                }
+            }
 
             // Show fields based on selected role
             switch (this.value) {
                 case 'Delegate':
                     delegateFields.style.display = 'block';
-                    if (delegateKmc) { delegateKmc.disabled = false; delegateKmc.required = true; }
+                    if (kmcField) {
+                        kmcField.style.display = 'block';
+                        const kmcInput = kmcField.querySelector('input');
+                        if (kmcInput) {
+                            kmcInput.required = true;
+                        }
+                    }
                     break;
                 case 'Faculty':
                     facultyFields.style.display = 'block';
-                    if (facultyKmc) { facultyKmc.disabled = false; facultyKmc.required = true; }
+                    if (kmcField) {
+                        kmcField.style.display = 'block';
+                        const kmcInput = kmcField.querySelector('input');
+                        if (kmcInput) {
+                            kmcInput.required = true;
+                        }
+                    }
                     break;
                 case 'Sponsor':
                     sponsorFields.style.display = 'block';
@@ -523,7 +537,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     </tr>
                     <tr>
                         <td><strong>KMC Number:</strong></td>
-                        <td>${document.getElementById('delegateKmcNumber').value || 'Not provided'}</td>
+                        <td>${document.getElementById('kmc_number').value || 'Not provided'}</td>
                     </tr>
                 `;
                 break;
@@ -544,7 +558,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     </tr>
                     <tr>
                         <td><strong>KMC Number:</strong></td>
-                        <td>${document.getElementById('facultyKmcNumber').value || 'Not provided'}</td>
+                        <td>${document.getElementById('kmc_number').value || 'Not provided'}</td>
                     </tr>
                     <tr>
                         <td><strong>Accommodation:</strong></td>


### PR DESCRIPTION
## Summary
- move KMC Number input to the first step of guest registration
- show or hide the KMC field based on selected role and require it for Delegate and Faculty
- document KMC field relocation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e1b5ecbe0832ca020e0a4d215b088