### PR TITLE
Add presentations CSV report export and UI button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,4 @@ All notable changes to this project will be documented in this file.
 - Introduce presentation approval workflow with dedicated approver login and CSV fields for selection status, marks, remarks, and approval date.
 - Lock presentation approvals after first decision and display approval status and remarks on admin and guest views with direct links to the review page.
 - Show KMC Number field in the first step of guest registration for Delegate and Faculty roles.
+- Add CSV export of presentations with judging details and an Export Report button on the admin presentations page.

--- a/templates/admin/presentations_management.html
+++ b/templates/admin/presentations_management.html
@@ -19,9 +19,14 @@
                 <h1 class="h3 mb-1">Presentations Management</h1>
                 <p class="text-muted mb-0">Review and download uploaded presentations</p>
             </div>
-            <a href="/admin/dashboard" class="btn btn-outline-secondary">
-                <i class="fas fa-arrow-left me-1"></i> Back to Dashboard
-            </a>
+            <div class="d-flex gap-2">
+                <a href="/admin/dashboard" class="btn btn-outline-secondary">
+                    <i class="fas fa-arrow-left me-1"></i> Back to Dashboard
+                </a>
+                <a href="/admin/report/export/presentations" class="btn btn-outline-success">
+                    <i class="fas fa-file-csv me-1"></i> Export Report
+                </a>
+            </div>
         </div>
         <div class="table-responsive mt-4">
             <table class="table table-bordered table-hover">


### PR DESCRIPTION
## Summary
- enable admins to export presentations with judging details as CSV
- add Export Report button to presentations management page
- document changes in changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0222a4100832cadb77de4b9c89884