### PR TITLE
feat: track guest availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,4 @@ All notable changes to this project will be documented in this file.
 - Lock presentation approvals after first decision and display approval status and remarks on admin and guest views with direct links to the review page.
 - Show KMC Number field in the first step of guest registration for Delegate and Faculty roles.
 - Add CSV export of presentations with judging details and an Export Report button on the admin presentations page.
+- Track guest availability for day 1, day 2, or both days across registration, admin views, profiles, and reports.

--- a/app/models/guest.py
+++ b/app/models/guest.py
@@ -56,6 +56,7 @@ class Guest:
         self.food_coupons_day2_date = ""
         self.gift_notes = ""
         self.food_notes = ""
+        self.availability = "Not Specified"
         
     @classmethod
     def from_dict(cls, data: Dict) -> 'Guest':
@@ -113,7 +114,8 @@ class Guest:
             "GiftsGiven": self.gifts_given,
             "GiftGivenDate": self.gift_given_date,
             "GiftNotes": self.gift_notes,
-            "FoodNotes": self.food_notes
+            "FoodNotes": self.food_notes,
+            "Availability": self.availability
         }
         
     def validate(self) -> List[str]:

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -492,7 +492,7 @@ def reset_main_database():
             "FoodCouponsDay2", "FoodCouponsDay1Date", "FoodCouponsDay2Date",
             "FoodNotes", "PaymentStatus", "PaymentAmount", "PaymentDate",
             "PaymentMethod", "JourneyDetailsUpdated", "JourneyCompleted",
-            "LastJourneyUpdate", "InwardJourneyDate", "InwardJourneyFrom",
+            "LastJourneyUpdate", "Availability", "InwardJourneyDate", "InwardJourneyFrom",
             "InwardJourneyTo", "InwardJourneyDetails", "InwardPickupRequired",
             "InwardJourneyRemarks", "OutwardJourneyDate", "OutwardJourneyFrom",
             "OutwardJourneyTo", "OutwardJourneyDetails", "OutwardDropRequired",
@@ -903,7 +903,7 @@ async def export_guest_list(
             
             # Write header
             writer.writerow([
-                "ID", "Name", "Email", "Phone", "KMC Number", "Role", "Registration Date",
+                "ID", "Name", "Email", "Phone", "KMC Number", "Role", "Registration Date", "Availability",
                 "Check-in Status", "Kit Status", "Badge Status", "Payment Status", "Amount"
             ])
             
@@ -917,6 +917,7 @@ async def export_guest_list(
                     guest.get("KMCNumber", ""),
                     guest.get("GuestRole", ""),
                     guest.get("RegistrationDate", ""),
+                    guest.get("Availability", "Not Specified"),
                     "Checked In" if guest.get("DailyAttendance") == "True" else "Not Checked In",
                     "Received" if guest.get("KitReceived") == "True" else "Not Received",
                     "Printed" if guest.get("BadgePrinted") == "True" else "Not Printed",
@@ -950,6 +951,7 @@ async def export_guest_list(
                         "KMC Number": guest.get("KMCNumber", ""),
                         "Role": guest.get("GuestRole", ""),
                         "Registration Date": guest.get("RegistrationDate", ""),
+                        "Availability": guest.get("Availability", "Not Specified"),
                         "Check-in Status": "Checked In" if guest.get("DailyAttendance") == "True" else "Not Checked In",
                         "Kit Status": "Received" if guest.get("KitReceived") == "True" else "Not Received",
                         "Badge Status": "Printed" if guest.get("BadgePrinted") == "True" else "Not Printed",
@@ -2844,6 +2846,7 @@ async def update_guest_basic_info(request: Request, admin: Dict = Depends(get_cu
         email = data.get('email')
         phone = data.get('phone')
         kmc_number = data.get('kmc_number')
+        availability = data.get('availability')
         
         guests = guests_db.read_all()
         updated = False
@@ -2854,6 +2857,7 @@ async def update_guest_basic_info(request: Request, admin: Dict = Depends(get_cu
                 guest["Email"] = email
                 guest["Phone"] = phone
                 guest["KMCNumber"] = kmc_number
+                guest["Availability"] = availability
                 updated = True
                 break
                 
@@ -3667,6 +3671,7 @@ def ensure_all_guest_fields():
             # Notes fields
             "GiftNotes": "",
             "FoodNotes": "",
+            "Availability": "Not Specified",
         }
 
         first_guest = guests[0]

--- a/app/routes/guest.py
+++ b/app/routes/guest.py
@@ -978,7 +978,8 @@ async def register_guest(
     guest_role: str = Form(...),
     registration_type: str = Form(...),
     existing_id: str = Form(None),
-    kmc_number: str = Form("")
+    kmc_number: str = Form(""),
+    availability: str = Form(...)
 ):
     """Process guest registration"""
     try:
@@ -1033,6 +1034,7 @@ async def register_guest(
             "Email": email or "",
             "GuestRole": guest_role,
             "KMCNumber": kmc_number,
+            "Availability": availability,
             "RegistrationDate": datetime.now().strftime("%Y-%m-%d"),
             "DailyAttendance": "False"
         }

--- a/docs/2025-08-15-guest-availability.md
+++ b/docs/2025-08-15-guest-availability.md
@@ -1,0 +1,15 @@
+# Guest Availability Tracking
+
+## Summary
+Added an `Availability` field to capture whether a guest will attend day 1, day 2, or both days of the conference.
+
+## Changes
+- `app/models/guest.py`: store availability with default "Not Specified" and include in CSV serialization.
+- `templates/guest_registration.html`: collect availability via required radio buttons during registration.
+- `app/routes/guest.py`: accept the new form field and persist it to the database.
+- `templates/admin/single_guest.html`: display and allow admins to update availability.
+- `app/routes/admin.py`: support availability in database initialization, field sanitization, basic info updates, and guest list exports.
+- `templates/guest/profile.html`: show availability on the guest's profile page.
+
+## Rationale
+Knowing which days guests plan to attend helps organizers plan resources and logistics accurately.

--- a/templates/admin/single_guest.html
+++ b/templates/admin/single_guest.html
@@ -559,7 +559,12 @@
                                         <label class="form-label fw-bold text-muted">Registration Date</label>
                                         <div class="editable-field">{{ guest.RegistrationDate or 'Not available' }}</div>
                                     </div>
-                                    
+
+                                    <div class="mb-3">
+                                        <label class="form-label fw-bold text-muted">Availability</label>
+                                        <div class="editable-field" id="displayAvailability">{{ guest.Availability or 'Not specified' }}</div>
+                                    </div>
+
                                     {# Batch field removed as it is irrelevant #}
                                     
                                     
@@ -599,6 +604,17 @@
                                         <div class="mb-3">
                                             <label class="form-label">KMC Number</label>
                                             <input type="text" class="form-control" id="editKMCNumber" value="{{ guest.KMCNumber or '' }}">
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div class="mb-3">
+                                            <label class="form-label">Availability</label>
+                                            <select class="form-select" id="editAvailability">
+                                                <option value="Not Specified" {% if guest.Availability == 'Not Specified' %}selected{% endif %}>Not Specified</option>
+                                                <option value="Day - 1 Available" {% if guest.Availability == 'Day - 1 Available' %}selected{% endif %}>Day - 1 Available</option>
+                                                <option value="Day - 2 Available" {% if guest.Availability == 'Day - 2 Available' %}selected{% endif %}>Day - 2 Available</option>
+                                                <option value="Both Days Available" {% if guest.Availability == 'Both Days Available' %}selected{% endif %}>Both Days Available</option>
+                                            </select>
                                         </div>
                                     </div>
                                 </div>
@@ -1659,6 +1675,7 @@
             const email = document.getElementById('editEmail').value;
             const phone = document.getElementById('editPhone').value;
             const kmcNumber = document.getElementById('editKMCNumber').value;
+            const availability = document.getElementById('editAvailability').value;
             
             showLoading('basicEdit');
             
@@ -1672,7 +1689,8 @@
                     name: name,
                     email: email,
                     phone: phone,
-                    kmc_number: kmcNumber
+                    kmc_number: kmcNumber,
+                    availability: availability
                 })
             })
             .then(response => response.json())
@@ -1684,6 +1702,7 @@
                     document.getElementById('displayEmail').textContent = email || 'Not provided';
                     document.getElementById('displayPhone').textContent = phone || 'Not provided';
                     document.getElementById('displayKMC').textContent = kmcNumber || 'Not provided';
+                    document.getElementById('displayAvailability').textContent = availability || 'Not specified';
                     
                     showNotification(data.message || 'Basic information updated successfully', 'success');
                     toggleBasicEdit();

--- a/templates/guest/profile.html
+++ b/templates/guest/profile.html
@@ -227,8 +227,15 @@
                             <strong>{{ guest.RegistrationDate }}</strong>
                         </div>
                     </div>
-                    
-                    
+
+
+                    <div class="info-row">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <small class="text-muted"><i class="fas fa-calendar-check me-1"></i>Availability:</small>
+                            <strong>{{ guest.Availability or 'Not specified' }}</strong>
+                        </div>
+                    </div>
+
                     <div class="info-row">
                         <div class="d-flex justify-content-between align-items-center">
                             <small class="text-muted"><i class="fas fa-user-check me-1"></i>Attendance:</small>

--- a/templates/guest_registration.html
+++ b/templates/guest_registration.html
@@ -180,6 +180,26 @@
                             </div>
                         </div>
 
+                        <div class="mb-3">
+                            <label class="form-label">Would you be available for the two days event?*</label>
+                            <div class="form-text">
+                                Day - 1: September 20, 2025; Saturday at 9.00 AM to 6.00 PM<br>
+                                Day - 2: September 21, 2025; Sunday at 9.00 AM to 6.00 PM
+                            </div>
+                            <div class="form-check mt-2">
+                                <input class="form-check-input" type="radio" name="availability" id="day1" value="Day - 1 Available" required>
+                                <label class="form-check-label" for="day1">Day - 1 Available</label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="availability" id="day2" value="Day - 2 Available" required>
+                                <label class="form-check-label" for="day2">Day - 2 Available</label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="availability" id="both" value="Both Days Available" required>
+                                <label class="form-check-label" for="both">Both Days Available</label>
+                            </div>
+                        </div>
+
                         <div class="d-flex justify-content-between mt-4">
                             <a href="/" class="btn btn-outline-secondary">
                                 <i class="fas fa-arrow-left me-1"></i> Cancel


### PR DESCRIPTION
## Summary
- add availability field to guest model and CSV exports
- collect and display availability in registration, admin, and guest views
- allow admins to edit availability and include it in reports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a72b944f64832c836cff4c4b35221e