### PR TITLE
Handle journey fields in guest CSV uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,3 +47,4 @@ All notable changes to this project will be documented in this file.
 - Add CSV export of presentations with judging details and an Export Report button on the admin presentations page.
 - Track guest availability for day 1, day 2, or both days across registration, admin views, profiles, and reports.
 - Resolve CSV upload failures by standardizing guest fieldnames against the model and enriching validation and error messages for admins.
+- Include journey fields in admin guest CSV uploads by defining a comprehensive master field list to prevent missing-field errors.


### PR DESCRIPTION
## Summary
- include journey-related headers in guest CSV upload processing
- ensure all guest records are normalized with a master field list
- document change in changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7624236b8832c8de67d8b934aa3d3