### PR TITLE
Require registration fields only for delegate and faculty roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,4 @@ All notable changes to this project will be documented in this file.
 - Track guest availability for day 1, day 2, or both days across registration, admin views, profiles, and reports.
 - Resolve CSV upload failures by standardizing guest fieldnames against the model and enriching validation and error messages for admins.
 - Include journey fields in admin guest CSV uploads by defining a comprehensive master field list to prevent missing-field errors.
+- Make registration fields mandatory only when Delegate or Faculty role is selected.

--- a/docs/2025-08-27-mandatory-fields-delegate-faculty.md
+++ b/docs/2025-08-27-mandatory-fields-delegate-faculty.md
@@ -1,0 +1,10 @@
+# Make registration fields mandatory for Delegate and Faculty roles
+
+## Context
+Previously, the registration form required basic information for all roles.
+
+## Change
+JavaScript now toggles the required attribute for basic and role-specific fields so that they become mandatory only when the user selects **Delegate** or **Faculty**.
+
+## Rationale
+Ensures complete data for conference participants while allowing other roles to register without unnecessary mandatory fields.

--- a/templates/guest_registration.html
+++ b/templates/guest_registration.html
@@ -404,6 +404,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const delegateFields = document.getElementById('delegate-fields');
     const facultyFields = document.getElementById('faculty-fields');
     const sponsorFields = document.getElementById('sponsor-fields');
+    const baseFields = ['name', 'phone', 'email'];
+    const availabilityInputs = document.querySelectorAll('input[name="availability"]');
 
     if (guestRoleSelect) {
         guestRoleSelect.addEventListener('change', function() {
@@ -411,6 +413,22 @@ document.addEventListener('DOMContentLoaded', function() {
             delegateFields.style.display = 'none';
             facultyFields.style.display = 'none';
             sponsorFields.style.display = 'none';
+
+            // Toggle base field requirements based on role
+            const isDelegateOrFaculty = this.value === 'Delegate' || this.value === 'Faculty';
+            baseFields.forEach(id => {
+                const field = document.getElementById(id);
+                if (field) field.required = isDelegateOrFaculty;
+            });
+            availabilityInputs.forEach(input => input.required = isDelegateOrFaculty);
+
+            // Reset role-specific requirements
+            const orgField = document.getElementById('organization');
+            if (orgField) orgField.required = false;
+            ['designation', 'institution', 'specialty'].forEach(id => {
+                const field = document.getElementById(id);
+                if (field) field.required = false;
+            });
 
             // Also hide the KMC field initially
             const kmcField = document.getElementById('kmc-field');
@@ -426,6 +444,7 @@ document.addEventListener('DOMContentLoaded', function() {
             switch (this.value) {
                 case 'Delegate':
                     delegateFields.style.display = 'block';
+                    if (orgField) orgField.required = true;
                     if (kmcField) {
                         kmcField.style.display = 'block';
                         const kmcInput = kmcField.querySelector('input');
@@ -436,6 +455,10 @@ document.addEventListener('DOMContentLoaded', function() {
                     break;
                 case 'Faculty':
                     facultyFields.style.display = 'block';
+                    ['designation', 'institution', 'specialty'].forEach(id => {
+                        const field = document.getElementById(id);
+                        if (field) field.required = true;
+                    });
                     if (kmcField) {
                         kmcField.style.display = 'block';
                         const kmcInput = kmcField.querySelector('input');
@@ -449,6 +472,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     break;
             }
         });
+        guestRoleSelect.dispatchEvent(new Event('change'));
     }
     
     // Handle form step navigation


### PR DESCRIPTION
## Summary
- Toggle registration form field requirements based on role, making fields mandatory only for Delegate or Faculty selections
- Document the new behavior in the changelog and change notes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb48b7d0c832c9b09416a7a15cf14