### PR TITLE
Link dashboard cards to guest lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Make admin dashboard stat cards link to filtered guest lists for quick navigation.
 - Add admin CSV guest upload with robust validation, duplicate checks, and dashboard link.
 - Standardize branding to "Magna Endocrine Update 2025" across templates, backend emails, badges, and tests.
 - Fix admin journey update deleting records due to mismatched CSV columns.

--- a/docs/2025-08-30-dashboard-card-links.md
+++ b/docs/2025-08-30-dashboard-card-links.md
@@ -1,0 +1,14 @@
+## Make dashboard stat cards link to guest lists
+
+- **Date:** 2025-08-30
+- **Author:** codex
+
+### Summary
+Converted admin dashboard stat cards into links that navigate to filtered guest lists for total guests, delegates, faculty, and present attendees.
+
+### Files Affected
+- `templates/admin/dashboard.html`
+- `CHANGELOG.md`
+
+### Rationale
+Provides quick navigation from dashboard metrics to the corresponding guest listings, streamlining admin workflows.

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -180,43 +180,51 @@
 <!-- Stats Overview Cards -->
 <div class="row mb-4">
     <div class="col-md-3">
-        <div class="stats-card primary mb-4">
-            <div class="stats-icon">
-                <i class="fas fa-users"></i>
+        <a href="/admin/all_guests" class="text-decoration-none">
+            <div class="stats-card primary mb-4">
+                <div class="stats-icon">
+                    <i class="fas fa-users"></i>
+                </div>
+                <div class="stats-number">{{ stats.total_guests }}</div>
+                <div class="stats-title">Total Guests</div>
             </div>
-            <div class="stats-number">{{ stats.total_guests }}</div>
-            <div class="stats-title">Total Guests</div>
-        </div>
+        </a>
     </div>
-    
+
     <div class="col-md-3">
-        <div class="stats-card success mb-4">
-            <div class="stats-icon">
-                <i class="fas fa-user-tie"></i>
+        <a href="/admin/all_guests?role=Delegate" class="text-decoration-none">
+            <div class="stats-card success mb-4">
+                <div class="stats-icon">
+                    <i class="fas fa-user-tie"></i>
+                </div>
+                <div class="stats-number">{{ stats.delegate_count }}</div>
+                <div class="stats-title">Delegates</div>
             </div>
-            <div class="stats-number">{{ stats.delegate_count }}</div>
-            <div class="stats-title">Delegates</div>
-        </div>
+        </a>
     </div>
-    
+
     <div class="col-md-3">
-        <div class="stats-card warning mb-4">
-            <div class="stats-icon">
-                <i class="fas fa-university"></i>
+        <a href="/admin/all_guests?role=Faculty" class="text-decoration-none">
+            <div class="stats-card warning mb-4">
+                <div class="stats-icon">
+                    <i class="fas fa-university"></i>
+                </div>
+                <div class="stats-number">{{ stats.faculty_count }}</div>
+                <div class="stats-title">Faculty</div>
             </div>
-            <div class="stats-number">{{ stats.faculty_count }}</div>
-            <div class="stats-title">Faculty</div>
-        </div>
+        </a>
     </div>
-    
+
     <div class="col-md-3">
-        <div class="stats-card info mb-4">
-            <div class="stats-icon">
-                <i class="fas fa-clipboard-check"></i>
+        <a href="/admin/all_guests?attendance=present" class="text-decoration-none">
+            <div class="stats-card info mb-4">
+                <div class="stats-icon">
+                    <i class="fas fa-clipboard-check"></i>
+                </div>
+                <div class="stats-number">{{ stats.attendance_count }}</div>
+                <div class="stats-title">Attendance Rate</div>
             </div>
-            <div class="stats-number">{{ stats.attendance_count }}</div>
-            <div class="stats-title">Attendance Rate</div>
-        </div>
+        </a>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Make admin dashboard stat cards link to filtered guest lists for guests, delegates, faculty, and attendees.
- Document the change and update the changelog.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1db9afe6c832cb488dff1c1bd0a29