### PR TITLE
Expand admin guests table to full width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,4 @@ All notable changes to this project will be documented in this file.
 - Include journey fields in admin guest CSV uploads by defining a comprehensive master field list to prevent missing-field errors.
 - Make registration fields mandatory only when Delegate or Faculty role is selected.
 - Send SMS notifications to coordinators and guests after successful registration using configurable templates.
+- Allow admin guest table to span full width with responsive scrolling.

--- a/docs/2025-08-29-full-width-guests-table.md
+++ b/docs/2025-08-29-full-width-guests-table.md
@@ -1,0 +1,15 @@
+## Ensure guest table uses full width
+
+- **Date:** 2025-08-29
+- **Author:** codex
+
+### Summary
+Expanded the admin guests table to occupy the full width of large displays by removing restrictive widths and enabling responsive horizontal scrolling.
+
+### Files Affected
+- `templates/admin/all_guests.html`
+- `static/css/styles.css`
+- `CHANGELOG.md`
+
+### Rationale
+Improves visibility and usability of guest data on desktop by allowing the table to use all available horizontal space while maintaining responsiveness on smaller screens.

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -387,11 +387,14 @@ body {
    border-radius: 0.5rem;
    box-shadow: 0 2px 10px rgba(0,0,0,0.05);
    background-color: white;
-   overflow: hidden;
+   overflow-x: auto; /* Ensure horizontal scroll on smaller screens */
+   overflow-y: hidden;
 }
 
 .table {
    margin-bottom: 0;
+   width: 100%; /* Make sure the table itself expands */
+   min-width: 700px; /* Optional: prevent columns from getting too narrow */
 }
 
 .table thead th {

--- a/templates/admin/all_guests.html
+++ b/templates/admin/all_guests.html
@@ -41,6 +41,13 @@
             color: white;
             border: none;
         }
+        .table-responsive {
+            width: 100%;
+            overflow-x: auto;
+        }
+        #guestsTable {
+            width: 100% !important;
+        }
     </style>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Remove fixed width constraints and set admin guests table and container to 100% width
- Add responsive overflow handling in global table styles
- Record changes in changelog and new documentation entry

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1dfddb650832c99549875127c2445