### PR TITLE
Replace homepage registration link with closed notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Replace homepage registration link with a disabled "Registration Closed" notice to reflect enrollment status.
 - Add QueryPreprocessorAgent for astrological query preprocessing and explicit termination to avoid agent loop.
 - Make admin dashboard stat cards link to filtered guest lists for quick navigation.
 - Add admin CSV guest upload with robust validation, duplicate checks, and dashboard link.

--- a/docs/2025-09-16-homepage-registration-closed.md
+++ b/docs/2025-09-16-homepage-registration-closed.md
@@ -1,0 +1,20 @@
+## Replace homepage registration link with "Registration Closed" notice
+
+- **Date:** 2025-09-16
+- **Author:** codex
+
+### Summary
+- Removed the homepage "New Registration" hyperlink and replaced it with a disabled button labelled "Registration Closed" so visitors know registration has ended.
+- Added styling for `.registration-closed-btn` to preserve the card layout while visually indicating the action is unavailable.
+
+### Files Affected
+- `templates/index.html`
+- `CHANGELOG.md`
+
+### Rationale
+The conference is no longer accepting new registrations, but the homepage previously invited visitors to register. Replacing the call-to-action with a closed notice prevents confusion while keeping the layout intact.
+
+### Implementation Notes
+- The button markup lives in `templates/index.html` under the "Primary Guest Actions" card. Look for the `registration-closed-btn` class when replicating this deployment.
+- To reopen registration in a future deployment, swap the `<button>` element back to an `<a href="/guest_registration">` link (or update the href to the new registration URL) and remove the `disabled` attribute.
+- The helper styles ensure the disabled button keeps consistent spacing and coloring. Adjust them or the button text as needed for other events.

--- a/templates/index.html
+++ b/templates/index.html
@@ -83,6 +83,31 @@
         transform: translateY(-2px);
         box-shadow: 0 8px 25px rgba(26, 35, 126, 0.3);
     }
+
+    .registration-closed-btn {
+        background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+        border: 2px dashed #6c757d;
+        color: #6c757d;
+        cursor: not-allowed;
+        box-shadow: none;
+    }
+
+    .registration-closed-btn:hover {
+        background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+        color: #6c757d;
+        border-color: #6c757d;
+        transform: none;
+        box-shadow: none;
+    }
+
+    .registration-closed-btn:disabled {
+        opacity: 1;
+    }
+
+    .registration-closed-btn .action-icon,
+    .registration-closed-btn .fa-lock {
+        color: #6c757d;
+    }
     
     .quick-scan-btn {
         background: linear-gradient(135deg, #dc3545 0%, #e74c3c 100%);
@@ -346,16 +371,16 @@
                     </div>
                     
                     <div class="col-md-6">
-                        <a href="/guest_registration" class="btn secondary-action-btn w-100 d-flex align-items-center justify-content-between text-decoration-none">
+                        <button type="button" class="btn secondary-action-btn registration-closed-btn w-100 d-flex align-items-center justify-content-between text-decoration-none" disabled>
                             <div class="text-start">
                                 <div class="d-flex align-items-center mb-2">
-                                    <i class="fas fa-user-plus action-icon"></i>
-                                    <span class="h5 mb-0 fw-bold">New Registration</span>
+                                    <i class="fas fa-user-lock action-icon"></i>
+                                    <span class="h5 mb-0 fw-bold">Registration Closed</span>
                                 </div>
-                                <small class="d-block">Register for the conference</small>
+                                <small class="d-block text-muted">Conference registration is currently closed</small>
                             </div>
-                            <i class="fas fa-chevron-right fa-lg"></i>
-                        </a>
+                            <i class="fas fa-lock fa-lg"></i>
+                        </button>
                     </div>
                 </div>
                 


### PR DESCRIPTION
## Summary
- replace the homepage "New Registration" link with a disabled "Registration Closed" button and supporting styles
- document how to manage the closed state for future deployments in `docs/2025-09-16-homepage-registration-closed.md`
- note the homepage change in the changelog

## Testing
- not run (HTML and documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68c9410e8e20832cb66647803e16f6ee